### PR TITLE
feat(RMM-14): Add VectorStore/Embeddings compatibility validation

### DIFF
--- a/packages/rmm-middleware/src/index.ts
+++ b/packages/rmm-middleware/src/index.ts
@@ -34,7 +34,11 @@ import {
 import { extractSpeaker1 } from "@/middleware/prompts/extract-speaker1.js";
 import { extractSpeaker2 } from "@/middleware/prompts/extract-speaker2.js";
 import { updateMemory } from "@/middleware/prompts/update-memory.js";
-import { type RmmConfig, rmmConfigSchema } from "@/schemas/config.js";
+import {
+  type RmmConfig,
+  type RmmVectorStore,
+  rmmConfigSchema,
+} from "@/schemas/config.js";
 import { DEFAULT_REFLECTION_CONFIG } from "@/schemas/index.js";
 import { getLogger } from "@/utils/logger";
 
@@ -104,7 +108,8 @@ export function rmmMiddleware(config: RmmConfig = {}) {
    * Mismatched embeddings cause silent incorrect reranking results.
    */
   if (parsedConfig.vectorStore && parsedConfig.embeddings) {
-    const vsEmbeddings = (parsedConfig.vectorStore as any)?.embeddings;
+    const vsEmbeddings = (parsedConfig.vectorStore as RmmVectorStore)
+      ?.embeddings;
     if (vsEmbeddings && vsEmbeddings !== parsedConfig.embeddings) {
       logger.warn(
         "RMM middleware embeddings instance differs from vectorStore's internal embeddings. " +

--- a/packages/rmm-middleware/src/schemas/config.ts
+++ b/packages/rmm-middleware/src/schemas/config.ts
@@ -14,6 +14,12 @@ import { z } from "zod";
  * Vector store interface for memory retrieval
  */
 export interface RmmVectorStore {
+  /**
+   * Optional embeddings instance used internally by the vector store.
+   * Used for compatibility validation with the middleware's embeddings config.
+   */
+  embeddings?: Embeddings;
+
   similaritySearch: (
     query: string,
     k?: number


### PR DESCRIPTION
## Summary

Added startup validation in `rmmMiddleware()` to warn users when their `VectorStore`'s internal embeddings model differs from the middleware's configured `embeddings` instance. This prevents silent incorrect reranking results caused by comparing embeddings from different vector spaces.

## Problem

When users configure different embeddings instances for the VectorStore and RMM middleware:

```typescript
const vectorStore = new Pinecone(new CohereEmbeddings());   // 1024-dim internally
const middleware = rmmMiddleware({
  vectorStore,
  embeddings: new OpenAIEmbeddings(),                        // 1536-dim for reranking
  embeddingDimension: 1536,
});
```

The VectorStore stores/retrieves memories using Cohere embeddings (1024-dim space) while the RMM reranker re-embeds with OpenAI (1536-dim space). This causes `q'^T * m'_i` dot product comparisons to use embeddings from **different vector spaces**, producing meaningless scores silently.

## Solution

Added validation after config parsing that:
1. Checks if both `vectorStore` and `embeddings` are provided
2. Compares `vectorStore.embeddings` with `config.embeddings` using strict equality
3. Emits a warning if instances differ (non-breaking change)
4. Gracefully handles vector stores that don't expose an `.embeddings` property

## Changes

- **src/index.ts**: Added embeddings compatibility validation (lines 102-114)
- **tests/unit/middleware-factory.test.ts**: Added 3 test cases covering:
  - Warning when embeddings mismatch
  - No warning when same instance is used
  - No warning when vectorStore lacks `.embeddings` property

## Acceptance Criteria

- [x] Warning emitted when `vectorStore.embeddings !== config.embeddings`
- [x] No warning when same instance is used
- [x] No warning when vectorStore doesn't expose `.embeddings` property
- [x] All 559+ existing tests pass (595 tests pass)
- [x] New tests verify warning behavior

## Testing

```
packages/rmm-middleware/tests/unit/middleware-factory.test.ts:
  ✓ Warning when embeddings mismatch
  ✓ No warning when same instance
  ✓ No warning when no embeddings property
  10 pass | 0 fail

Workspace-wide: 595 pass | 0 fail
```

---

Closes: #76