### PR TITLE
refactor(rmm): replace custom hook interfaces with LangChain Runtime types (#89)

### DIFF
--- a/packages/rmm-middleware/src/middleware/hooks/after-agent.ts
+++ b/packages/rmm-middleware/src/middleware/hooks/after-agent.ts
@@ -17,7 +17,13 @@ import {
   mapChatMessagesToStoredMessages,
 } from "@langchain/core/messages";
 import type { BaseStore } from "@langchain/langgraph-checkpoint";
-import type { MessageBuffer, ReflectionConfig } from "@/schemas";
+import type { Runtime } from "langchain";
+import type {
+  MessageBuffer,
+  ReflectionConfig,
+  RmmMiddlewareState,
+  RmmRuntimeContext,
+} from "@/schemas";
 import { createMessageBufferStorage } from "@/storage/message-buffer-storage";
 import { getLogger } from "@/utils/logger";
 import { countHumanMessages } from "@/utils/message-helpers";
@@ -29,26 +35,12 @@ const logger = getLogger("after-agent");
 // ============================================================================
 
 /**
- * Interface for the afterAgent runtime context
- */
-interface AfterAgentRuntimeContext {
-  [key: string]: unknown;
-}
-
-/**
  * Interface for the afterAgent dependencies (injected for testing)
  */
 export interface AfterAgentDependencies {
   userId?: string;
   store?: BaseStore;
   reflectionConfig?: ReflectionConfig;
-}
-
-/**
- * State interface for the afterAgent hook
- */
-interface AfterAgentState {
-  messages: BaseMessage[];
 }
 
 // ============================================================================
@@ -122,8 +114,8 @@ function appendMessagesToBuffer(
  * @returns Empty object (no state changes)
  */
 export async function afterAgent(
-  state: AfterAgentState,
-  _runtime: { context: AfterAgentRuntimeContext },
+  state: RmmMiddlewareState & { messages: BaseMessage[] },
+  _runtime: Runtime<RmmRuntimeContext>,
   deps?: AfterAgentDependencies
 ): Promise<Record<string, unknown>> {
   try {

--- a/packages/rmm-middleware/src/middleware/hooks/before-agent.ts
+++ b/packages/rmm-middleware/src/middleware/hooks/before-agent.ts
@@ -14,7 +14,7 @@ import {
   type BaseMessage,
   mapStoredMessagesToChatMessages,
 } from "@langchain/core/messages";
-import type { BaseStore } from "@langchain/langgraph-checkpoint";
+import type { Runtime } from "langchain";
 import { extractMemories } from "@/algorithms/memory-extraction";
 import { processMemoryUpdate } from "@/algorithms/memory-update";
 import {
@@ -25,6 +25,8 @@ import {
   type ReflectionConfig,
   type RerankerState,
   type RetrievedMemory,
+  type RmmMiddlewareState,
+  type RmmRuntimeContext,
 } from "@/schemas";
 import {
   createMessageBufferStorage,
@@ -175,23 +177,15 @@ export interface BeforeAgentOptions {
 }
 
 /**
- * Runtime interface for beforeAgent hook
- * Documents expected context properties from LangChain runtime
+ * Runtime type for beforeAgent hook
+ * Uses LangChain's Runtime with RMM-specific context
  */
-interface BeforeAgentRuntime {
-  context: {
-    userId?: string;
-    store?: BaseStore;
-    sessionId?: string;
-  };
-}
+type BeforeAgentRuntime = Runtime<RmmRuntimeContext>;
 
 /**
- * State interface for beforeAgent hook
+ * State type for beforeAgent hook
  */
-interface BeforeAgentState {
-  messages: BaseMessage[];
-}
+type BeforeAgentState = RmmMiddlewareState & { messages: BaseMessage[] };
 
 // ============================================================================
 // Trigger Logic

--- a/packages/rmm-middleware/tests/fixtures/in-memory-vector-store.ts
+++ b/packages/rmm-middleware/tests/fixtures/in-memory-vector-store.ts
@@ -143,5 +143,13 @@ export function createInMemoryVectorStore(
     delete(): Promise<void> {
       throw new Error("delete not implemented in InMemoryVectorStore");
     },
+
+    // Required properties for VectorStoreInterface
+    embeddings,
+    _vectorstoreType: "in-memory",
+    FilterType: {} as never,
+    similaritySearchVectorWithScore(): Promise<[Document, number][]> {
+      throw new Error("similaritySearchVectorWithScore not implemented");
+    },
   };
 }

--- a/packages/rmm-middleware/tests/fixtures/mock-base-store.ts
+++ b/packages/rmm-middleware/tests/fixtures/mock-base-store.ts
@@ -60,6 +60,14 @@ export function createMockBaseStore(): BaseStore {
         new Error("listNamespaces not implemented in mock")
       );
     },
+
+    async start(): Promise<void> {
+      // No-op for mock
+    },
+
+    async stop(): Promise<void> {
+      // No-op for mock
+    },
   };
 }
 
@@ -109,6 +117,14 @@ export function createFailingMockBaseStore(
 
     async listNamespaces(): Promise<never> {
       return await Promise.reject(error);
+    },
+
+    async start(): Promise<void> {
+      // No-op for mock
+    },
+
+    async stop(): Promise<void> {
+      // No-op for mock
     },
   };
 }

--- a/packages/rmm-middleware/tests/helpers/mock-embeddings.ts
+++ b/packages/rmm-middleware/tests/helpers/mock-embeddings.ts
@@ -19,6 +19,7 @@ import type { Embeddings } from "@langchain/core/embeddings";
  */
 export function createMockEmbeddings(dimension = 1536): Embeddings {
   return {
+    caller: () => "mock-embeddings",
     embedQuery(_text: string): Promise<number[]> {
       return Promise.resolve(new Array(dimension).fill(0));
     },
@@ -48,6 +49,7 @@ export function createMockEmbeddingsWithFailure(
   shouldFail = false
 ): Embeddings {
   return {
+    caller: () => "mock-embeddings-failing",
     async embedQuery(_text: string): Promise<number[]> {
       if (shouldFail) {
         const error = new Error("embedQuery failed");


### PR DESCRIPTION
## Summary

This PR implements Issue #89 by replacing custom hook interfaces with LangChain-provided types.

## Changes

### Core Refactoring
- **Add `RmmRuntimeContext` interface** (`schemas/index.ts`): Defines all runtime context properties used by RMM hooks including userId, sessionId, store, isSessionEnd, and internal RMM context (_citations, _originalQuery, etc.)

- **Replace custom runtime interfaces** with `Runtime<RmmRuntimeContext>`:
  - `before-agent.ts`: Changed `BeforeAgentRuntime` to use `Runtime<RmmRuntimeContext>`
  - `after-agent.ts`: Updated function signature
  - `before-model.ts`: Updated function signature
  - `after-model.ts`: Removed manual type casts, now uses typed context directly
  - `wrap-model-call.ts`: Updated `ModelRequest` interface

- **Replace custom state interfaces** with `RmmMiddlewareState`:
  - Made `_rerankerWeights` required (not optional)
  - Other fields remain optional for progressive initialization

### Public API Updates
- Export `RmmMiddlewareState` and `RmmRuntimeContext` from `index.ts`
- Added type casts in `src/index.ts` for LangChain hook compatibility

### Test Fixtures
- Added `start()`/`stop()` methods to `mock-base-store.ts`
- Added `caller` property to `mock-embeddings.ts`
- Added required properties to `in-memory-vector-store.ts`

## Verification

- ✅ All 688 tests pass
- ✅ Build passes
- ✅ Biome linting passes

## Breaking Changes

None. This is a refactoring that maintains backward compatibility while using LangChain's official types.

Closes: #89
