### PR TITLE
test(workspaces): add integration tests and increase coverage to 97%

### DIFF
--- a/packages/workspaces-middleware/src/presentation/index.ts
+++ b/packages/workspaces-middleware/src/presentation/index.ts
@@ -4,6 +4,8 @@ import type { AccessScope as DomainAccessScope } from "@/domain/models";
 import type { BaseStoreLike } from "@/infrastructure/virtual-store";
 import { createWorkspacesMiddleware as createWorkspacesMiddlewareImpl } from "@/presentation/middleware";
 
+export type { BaseStoreLike } from "@/infrastructure/virtual-store";
+
 export type AccessScope = DomainAccessScope;
 
 export interface PhysicalStoreConfig {

--- a/packages/workspaces-middleware/tests/integration/presentation/middleware.e2e.test.ts
+++ b/packages/workspaces-middleware/tests/integration/presentation/middleware.e2e.test.ts
@@ -1,0 +1,344 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ToolMessage } from "@langchain/core/messages";
+import { z } from "zod";
+
+import type {
+  RegisteredTool,
+  WorkspacesMiddlewareOptions,
+} from "@/presentation/index";
+import { createWorkspacesMiddleware } from "@/presentation/middleware";
+
+let workspaceRoot = "";
+
+beforeEach(async () => {
+  workspaceRoot = await mkdtemp(join(tmpdir(), "ws-middleware-e2e-phys-"));
+  await mkdir(join(workspaceRoot, "docs"), { recursive: true });
+  await mkdir(join(workspaceRoot, "data"), { recursive: true });
+  await writeFile(
+    join(workspaceRoot, "docs", "readme.md"),
+    "# Hello World",
+    "utf8"
+  );
+  await writeFile(join(workspaceRoot, "docs", "api.md"), "# API Docs", "utf8");
+  await writeFile(
+    join(workspaceRoot, "data", "config.json"),
+    '{"key": "value"}',
+    "utf8"
+  );
+});
+
+afterEach(async () => {
+  if (workspaceRoot !== "") {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+function createReadTool(): RegisteredTool {
+  return {
+    name: "read_file",
+    description: "Read a file from the workspace",
+    parameters: z.object({ path: z.string() }),
+    operations: ["read"],
+    handler: async (params, services) => {
+      const input = params as { path: string };
+      const resolved = services.resolve(input.path);
+      const content = await services.read(resolved.normalizedKey);
+      return { content };
+    },
+  };
+}
+
+function createWriteTool(): RegisteredTool {
+  return {
+    name: "write_file",
+    description: "Write content to a file",
+    parameters: z.object({ path: z.string(), content: z.string() }),
+    operations: ["write"],
+    handler: async (params, services) => {
+      const input = params as { path: string; content: string };
+      const resolved = services.resolve(input.path);
+      await services.write(resolved.normalizedKey, input.content);
+      return { content: "File written successfully" };
+    },
+  };
+}
+
+function createListTool(): RegisteredTool {
+  return {
+    name: "list_files",
+    description: "List files in a directory",
+    parameters: z.object({ path: z.string() }),
+    operations: ["list"],
+    handler: async (params, services) => {
+      const input = params as { path: string };
+      const resolved = services.resolve(input.path);
+      const files = await services.list(resolved.normalizedKey);
+      return { content: files.join("\n") };
+    },
+  };
+}
+
+function createEditTool(): RegisteredTool {
+  return {
+    name: "edit_file",
+    description: "Edit a file (read + write)",
+    parameters: z.object({ path: z.string(), content: z.string() }),
+    operations: ["edit"],
+    handler: async (params, services) => {
+      const input = params as { path: string; content: string };
+      const resolved = services.resolve(input.path);
+      await services.write(resolved.normalizedKey, input.content);
+      return { content: "File edited successfully" };
+    },
+  };
+}
+
+describe("E2E: Full middleware flow with physical mounts", () => {
+  test("executes read operation through middleware", async () => {
+    const options: WorkspacesMiddlewareOptions = {
+      mounts: [
+        {
+          prefix: "/project",
+          scope: "READ_ONLY",
+          store: { type: "physical", rootDir: workspaceRoot },
+        },
+      ],
+      tools: [createReadTool()],
+    };
+
+    const middleware = createWorkspacesMiddleware(options);
+    const wrapToolCall = middleware.wrapToolCall as NonNullable<
+      typeof middleware.wrapToolCall
+    >;
+
+    const result = await wrapToolCall(
+      {
+        toolCall: {
+          id: "e2e-read-1",
+          name: "read_file",
+          args: { path: "/project/docs/readme.md" },
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    expect((result as ToolMessage).content).toBe("# Hello World");
+  });
+
+  test("executes write operation through middleware", async () => {
+    const options: WorkspacesMiddlewareOptions = {
+      mounts: [
+        {
+          prefix: "/project",
+          scope: "READ_WRITE",
+          store: { type: "physical", rootDir: workspaceRoot },
+        },
+      ],
+      tools: [createWriteTool()],
+    };
+
+    const middleware = createWorkspacesMiddleware(options);
+    const wrapToolCall = middleware.wrapToolCall as NonNullable<
+      typeof middleware.wrapToolCall
+    >;
+
+    const result = await wrapToolCall(
+      {
+        toolCall: {
+          id: "e2e-write-1",
+          name: "write_file",
+          args: { path: "/project/data/new.txt", content: "new content" },
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    expect((result as ToolMessage).content).toBe("File written successfully");
+
+    // Verify file was actually written
+    const fileContent = await readFile(
+      join(workspaceRoot, "data", "new.txt"),
+      "utf8"
+    );
+    expect(fileContent).toBe("new content");
+  });
+
+  test("executes list operation through middleware", async () => {
+    const options: WorkspacesMiddlewareOptions = {
+      mounts: [
+        {
+          prefix: "/project",
+          scope: "READ_ONLY",
+          store: { type: "physical", rootDir: workspaceRoot },
+        },
+      ],
+      tools: [createListTool()],
+    };
+
+    const middleware = createWorkspacesMiddleware(options);
+    const wrapToolCall = middleware.wrapToolCall as NonNullable<
+      typeof middleware.wrapToolCall
+    >;
+
+    const result = await wrapToolCall(
+      {
+        toolCall: {
+          id: "e2e-list-1",
+          name: "list_files",
+          args: { path: "/project/docs" },
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    expect((result as ToolMessage).content).toContain("readme.md");
+    expect((result as ToolMessage).content).toContain("api.md");
+  });
+
+  test("unauthorized operations return graceful ToolMessage failures", async () => {
+    // Configure READ_ONLY but try to write
+    const options: WorkspacesMiddlewareOptions = {
+      mounts: [
+        {
+          prefix: "/project",
+          scope: "READ_ONLY",
+          store: { type: "physical", rootDir: workspaceRoot },
+        },
+      ],
+      tools: [createWriteTool()],
+    };
+
+    const middleware = createWorkspacesMiddleware(options);
+    const wrapToolCall = middleware.wrapToolCall as NonNullable<
+      typeof middleware.wrapToolCall
+    >;
+
+    const result = await wrapToolCall(
+      {
+        toolCall: {
+          id: "e2e-unauthorized-1",
+          name: "write_file",
+          args: { path: "/project/docs/readme.md", content: "hacked" },
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    expect((result as ToolMessage).content).toContain("not allowed");
+    expect((result as ToolMessage).status).toBe("error");
+
+    // Verify original file was NOT modified
+    const fileContent = await readFile(
+      join(workspaceRoot, "docs", "readme.md"),
+      "utf8"
+    );
+    expect(fileContent).toBe("# Hello World");
+  });
+
+  test("maintains runtime stability - no unhandled exception crash", async () => {
+    const options: WorkspacesMiddlewareOptions = {
+      mounts: [
+        {
+          prefix: "/project",
+          scope: "READ_ONLY",
+          store: { type: "physical", rootDir: workspaceRoot },
+        },
+      ],
+      tools: [createReadTool()],
+    };
+
+    const middleware = createWorkspacesMiddleware(options);
+    const wrapToolCall = middleware.wrapToolCall as NonNullable<
+      typeof middleware.wrapToolCall
+    >;
+
+    // Multiple operations should not crash
+    for (let i = 0; i < 10; i++) {
+      const result = await wrapToolCall(
+        {
+          toolCall: {
+            id: `e2e-stable-${i}`,
+            name: "read_file",
+            args: { path: "/project/docs/readme.md" },
+          },
+          runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+          state: { messages: [] },
+        } as never,
+        () => {
+          throw new Error("fallback should not run");
+        }
+      );
+
+      expect(result).toBeInstanceOf(ToolMessage);
+    }
+  });
+
+  test("executes edit operation through middleware", async () => {
+    const options: WorkspacesMiddlewareOptions = {
+      mounts: [
+        {
+          prefix: "/project",
+          scope: "READ_WRITE",
+          store: { type: "physical", rootDir: workspaceRoot },
+        },
+      ],
+      tools: [createEditTool()],
+    };
+
+    const middleware = createWorkspacesMiddleware(options);
+    const wrapToolCall = middleware.wrapToolCall as NonNullable<
+      typeof middleware.wrapToolCall
+    >;
+
+    const result = await wrapToolCall(
+      {
+        toolCall: {
+          id: "e2e-edit-1",
+          name: "edit_file",
+          args: {
+            path: "/project/docs/readme.md",
+            content: "# Updated Content",
+          },
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    expect((result as ToolMessage).content).toBe("File edited successfully");
+
+    // Verify file was actually edited
+    const fileContent = await readFile(
+      join(workspaceRoot, "docs", "readme.md"),
+      "utf8"
+    );
+    expect(fileContent).toBe("# Updated Content");
+  });
+});

--- a/packages/workspaces-middleware/tests/integration/presentation/middleware.isolation.e2e.test.ts
+++ b/packages/workspaces-middleware/tests/integration/presentation/middleware.isolation.e2e.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, test } from "bun:test";
+import { ToolMessage } from "@langchain/core/messages";
+import { InMemoryStore } from "@langchain/core/stores";
+import { z } from "zod";
+
+import { buildBaseStoreKey } from "@/infrastructure/virtual-store";
+import type {
+  BaseStoreLike,
+  RegisteredTool,
+  WorkspacesMiddlewareOptions,
+} from "@/presentation/index";
+import { createWorkspacesMiddleware } from "@/presentation/middleware";
+
+// Regex patterns for error matching - defined at top level for performance
+const ACCESS_DENIED_PATTERN = /not allowed|does not map|AccessDenied/;
+const SCOPE_VIOLATION_PATTERN = /not allowed|not permitted/;
+
+// Create a BaseStoreLike from LangChain's InMemoryStore
+function createBaseStoreLike(): BaseStoreLike {
+  const store = new InMemoryStore<string>();
+
+  return {
+    mget: async (keys) => store.mget(keys),
+    mset: async (keyValuePairs) => store.mset(keyValuePairs),
+    mdelete: async (keys) => store.mdelete(keys),
+    yieldKeys(prefix?: string): AsyncGenerator<string> {
+      return store.yieldKeys(prefix);
+    },
+  };
+}
+
+function createVirtualReadTool(): RegisteredTool {
+  return {
+    name: "read_virtual_file",
+    description: "Read a file from virtual storage",
+    parameters: z.object({ path: z.string() }),
+    operations: ["read"],
+    handler: async (params, services) => {
+      const input = params as { path: string };
+      const resolved = services.resolve(input.path);
+      const content = await services.read(resolved.normalizedKey);
+      return { content };
+    },
+  };
+}
+
+function createVirtualWriteTool(): RegisteredTool {
+  return {
+    name: "write_virtual_file",
+    description: "Write content to virtual storage",
+    parameters: z.object({ path: z.string(), content: z.string() }),
+    operations: ["write"],
+    handler: async (params, services) => {
+      const input = params as { path: string; content: string };
+      const resolved = services.resolve(input.path);
+      await services.write(resolved.normalizedKey, input.content);
+      return { content: "Virtual file written" };
+    },
+  };
+}
+
+describe("E2E: Concurrent virtual namespace isolation", () => {
+  test("two agents with isolated virtual namespaces do not contaminate each other", async () => {
+    // Shared store but different namespaces
+    const sharedStore = createBaseStoreLike();
+
+    // Agent A - has access to namespace ["workspaces", "agent-a"]
+    const agentAMounts: WorkspacesMiddlewareOptions["mounts"] = [
+      {
+        prefix: "/agent-a",
+        scope: "READ_WRITE",
+        store: { type: "virtual", namespace: ["workspaces", "agent-a"] },
+      },
+    ];
+
+    // Agent B - has access to namespace ["workspaces", "agent-b"]
+    const agentBMounts: WorkspacesMiddlewareOptions["mounts"] = [
+      {
+        prefix: "/agent-b",
+        scope: "READ_WRITE",
+        store: { type: "virtual", namespace: ["workspaces", "agent-b"] },
+      },
+    ];
+
+    // Create both middlewares with the same store but different mounts
+    const agentAMiddleware = createWorkspacesMiddleware({
+      mounts: agentAMounts,
+      tools: [createVirtualReadTool(), createVirtualWriteTool()],
+      virtualStore: sharedStore,
+    });
+
+    const agentBMiddleware = createWorkspacesMiddleware({
+      mounts: agentBMounts,
+      tools: [createVirtualReadTool(), createVirtualWriteTool()],
+      virtualStore: sharedStore,
+    });
+
+    const agentAWrapToolCall = agentAMiddleware.wrapToolCall as NonNullable<
+      typeof agentAMiddleware.wrapToolCall
+    >;
+    const agentBWrapToolCall = agentBMiddleware.wrapToolCall as NonNullable<
+      typeof agentBMiddleware.wrapToolCall
+    >;
+
+    // Agent A writes to its namespace
+    const agentAWriteResult = await agentAWrapToolCall(
+      {
+        toolCall: {
+          id: "agent-a-write",
+          name: "write_virtual_file",
+          args: { path: "/agent-a/shared.txt", content: "Agent A content" },
+        },
+        runtime: { context: { threadId: "thread-a", runId: "run-a" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(agentAWriteResult).toBeInstanceOf(ToolMessage);
+
+    // Agent B writes to its namespace (same filename, different namespace)
+    const agentBWriteResult = await agentBWrapToolCall(
+      {
+        toolCall: {
+          id: "agent-b-write",
+          name: "write_virtual_file",
+          args: { path: "/agent-b/shared.txt", content: "Agent B content" },
+        },
+        runtime: { context: { threadId: "thread-b", runId: "run-b" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(agentBWriteResult).toBeInstanceOf(ToolMessage);
+
+    // Agent A reads back - should get Agent A content
+    const agentAReadResult = await agentAWrapToolCall(
+      {
+        toolCall: {
+          id: "agent-a-read",
+          name: "read_virtual_file",
+          args: { path: "/agent-a/shared.txt" },
+        },
+        runtime: { context: { threadId: "thread-a", runId: "run-a" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(agentAReadResult).toBeInstanceOf(ToolMessage);
+    expect((agentAReadResult as ToolMessage).content).toBe("Agent A content");
+
+    // Agent B reads back - should get Agent B content
+    const agentBReadResult = await agentBWrapToolCall(
+      {
+        toolCall: {
+          id: "agent-b-read",
+          name: "read_virtual_file",
+          args: { path: "/agent-b/shared.txt" },
+        },
+        runtime: { context: { threadId: "thread-b", runId: "run-b" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(agentBReadResult).toBeInstanceOf(ToolMessage);
+    expect((agentBReadResult as ToolMessage).content).toBe("Agent B content");
+
+    // Verify no cross-contamination: Agent A cannot read Agent B's file
+    const agentACannotReadB = await agentAWrapToolCall(
+      {
+        toolCall: {
+          id: "agent-a-cross-read",
+          name: "read_virtual_file",
+          args: { path: "/agent-b/shared.txt" },
+        },
+        runtime: { context: { threadId: "thread-a", runId: "run-a" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    // Should get an error because /agent-b doesn't exist in Agent A's mounts
+    expect(agentACannotReadB).toBeInstanceOf(ToolMessage);
+    // The middleware denies access because /agent-b is not in Agent A's workspace configuration
+    expect((agentACannotReadB as ToolMessage).content).toMatch(
+      ACCESS_DENIED_PATTERN
+    );
+  });
+
+  test("parallel reads and writes maintain isolation", async () => {
+    const sharedStore = createBaseStoreLike();
+
+    // Multiple agents with different namespaces
+    const agents = ["alice", "bob", "charlie"].map((name) => {
+      const middleware = createWorkspacesMiddleware({
+        mounts: [
+          {
+            prefix: `/${name}`,
+            scope: "READ_WRITE",
+            store: { type: "virtual", namespace: ["workspaces", name] },
+          },
+        ],
+        tools: [createVirtualReadTool(), createVirtualWriteTool()],
+        virtualStore: sharedStore,
+      });
+
+      return {
+        name,
+        wrapToolCall: middleware.wrapToolCall as NonNullable<
+          typeof middleware.wrapToolCall
+        >,
+      };
+    });
+
+    // All agents write simultaneously
+    await Promise.all(
+      agents.map((agent) =>
+        agent.wrapToolCall(
+          {
+            toolCall: {
+              id: `parallel-write-${agent.name}`,
+              name: "write_virtual_file",
+              args: {
+                path: `/${agent.name}/data.txt`,
+                content: `${agent.name}'s data`,
+              },
+            },
+            runtime: {
+              context: {
+                threadId: `thread-${agent.name}`,
+                runId: `run-${agent.name}`,
+              },
+            },
+            state: { messages: [] },
+          } as never,
+          () => {
+            throw new Error("fallback should not run");
+          }
+        )
+      )
+    );
+
+    // All agents read simultaneously and verify isolation
+    const results = await Promise.all(
+      agents.map((agent) =>
+        agent.wrapToolCall(
+          {
+            toolCall: {
+              id: `parallel-read-${agent.name}`,
+              name: "read_virtual_file",
+              args: { path: `/${agent.name}/data.txt` },
+            },
+            runtime: {
+              context: {
+                threadId: `thread-${agent.name}`,
+                runId: `run-${agent.name}`,
+              },
+            },
+            state: { messages: [] },
+          } as never,
+          () => {
+            throw new Error("fallback should not run");
+          }
+        )
+      )
+    );
+
+    // Each agent should read its own data
+    for (let i = 0; i < agents.length; i++) {
+      expect(results[i]).toBeInstanceOf(ToolMessage);
+      expect((results[i] as ToolMessage).content).toBe(
+        `${agents[i].name}'s data`
+      );
+    }
+  });
+
+  test("virtual namespace isolation with read-only and read-write mixed scopes", async () => {
+    const sharedStore = createBaseStoreLike();
+    const sharedNamespace = ["workspaces", "shared"];
+    const privateNamespace = ["workspaces", "private"];
+
+    // Pre-populate data using correct key format
+    await sharedStore.mset([
+      [buildBaseStoreKey(sharedNamespace, "public.txt"), "public content"],
+      [buildBaseStoreKey(sharedNamespace, "private.txt"), "private content"],
+    ]);
+
+    // Agent with mixed scopes
+    const mixedScopeMiddleware = createWorkspacesMiddleware({
+      mounts: [
+        {
+          prefix: "/public",
+          scope: "READ_ONLY",
+          store: { type: "virtual", namespace: sharedNamespace },
+        },
+        {
+          prefix: "/private",
+          scope: "READ_WRITE",
+          store: { type: "virtual", namespace: privateNamespace },
+        },
+      ],
+      tools: [createVirtualReadTool(), createVirtualWriteTool()],
+      virtualStore: sharedStore,
+    });
+
+    const wrapToolCall = mixedScopeMiddleware.wrapToolCall as NonNullable<
+      typeof mixedScopeMiddleware.wrapToolCall
+    >;
+
+    // Read from public namespace should work
+    const publicRead = await wrapToolCall(
+      {
+        toolCall: {
+          id: "public-read",
+          name: "read_virtual_file",
+          args: { path: "/public/public.txt" },
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(publicRead).toBeInstanceOf(ToolMessage);
+    expect((publicRead as ToolMessage).content).toBe("public content");
+
+    // Write to public namespace should fail (READ_ONLY)
+    const publicWrite = await wrapToolCall(
+      {
+        toolCall: {
+          id: "public-write-attempt",
+          name: "write_virtual_file",
+          args: { path: "/public/hacked.txt", content: "hacked" },
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(publicWrite).toBeInstanceOf(ToolMessage);
+    // Either tool not allowed or scope violation - both are acceptable
+    expect((publicWrite as ToolMessage).content).toMatch(
+      SCOPE_VIOLATION_PATTERN
+    );
+
+    // Write to private namespace should work
+    const privateWrite = await wrapToolCall(
+      {
+        toolCall: {
+          id: "private-write",
+          name: "write_virtual_file",
+          args: { path: "/private/secret.txt", content: "secret data" },
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(privateWrite).toBeInstanceOf(ToolMessage);
+    expect((privateWrite as ToolMessage).content).toBe("Virtual file written");
+  });
+});

--- a/packages/workspaces-middleware/tests/integration/presentation/middleware.virtual.e2e.test.ts
+++ b/packages/workspaces-middleware/tests/integration/presentation/middleware.virtual.e2e.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, test } from "bun:test";
+import { ToolMessage } from "@langchain/core/messages";
+import { InMemoryStore } from "@langchain/core/stores";
+import { z } from "zod";
+
+import { buildBaseStoreKey } from "@/infrastructure/virtual-store";
+import type {
+  BaseStoreLike,
+  RegisteredTool,
+  WorkspacesMiddlewareOptions,
+} from "@/presentation/index";
+import { createWorkspacesMiddleware } from "@/presentation/middleware";
+
+// Create a BaseStoreLike from LangChain's InMemoryStore
+function createBaseStoreLike(): BaseStoreLike {
+  const store = new InMemoryStore<string>();
+
+  return {
+    mget: async (keys) => store.mget(keys),
+    mset: async (keyValuePairs) => store.mset(keyValuePairs),
+    mdelete: async (keys) => store.mdelete(keys),
+    yieldKeys(prefix?: string): AsyncGenerator<string> {
+      return store.yieldKeys(prefix);
+    },
+  };
+}
+
+function createVirtualReadTool(): RegisteredTool {
+  return {
+    name: "read_virtual_file",
+    description: "Read a file from virtual storage",
+    parameters: z.object({ path: z.string() }),
+    operations: ["read"],
+    handler: async (params, services) => {
+      const input = params as { path: string };
+      const resolved = services.resolve(input.path);
+      const content = await services.read(resolved.normalizedKey);
+      return { content };
+    },
+  };
+}
+
+function createVirtualWriteTool(): RegisteredTool {
+  return {
+    name: "write_virtual_file",
+    description: "Write content to virtual storage",
+    parameters: z.object({ path: z.string(), content: z.string() }),
+    operations: ["write"],
+    handler: async (params, services) => {
+      const input = params as { path: string; content: string };
+      const resolved = services.resolve(input.path);
+      await services.write(resolved.normalizedKey, input.content);
+      return { content: "Virtual file written" };
+    },
+  };
+}
+
+function createVirtualListTool(): RegisteredTool {
+  return {
+    name: "list_virtual_files",
+    description: "List files in virtual storage",
+    parameters: z.object({ path: z.string() }),
+    operations: ["list"],
+    handler: async (params, services) => {
+      const input = params as { path: string };
+      const resolved = services.resolve(input.path);
+      const files = await services.list(resolved.normalizedKey);
+      return { content: files.join("\n") };
+    },
+  };
+}
+
+describe("E2E: Full middleware flow with virtual mounts", () => {
+  test("executes read operation through middleware with virtual mount", async () => {
+    const virtualStore = createBaseStoreLike();
+    const namespace = ["workspaces", "test"];
+
+    // Pre-populate some data using correct key format
+    await virtualStore.mset([
+      [buildBaseStoreKey(namespace, "docs/readme.md"), "# Virtual Hello"],
+      [buildBaseStoreKey(namespace, "docs/api.md"), "# Virtual API"],
+    ]);
+
+    const options: WorkspacesMiddlewareOptions = {
+      mounts: [
+        {
+          prefix: "/virtual",
+          scope: "READ_ONLY",
+          store: { type: "virtual", namespace },
+        },
+      ],
+      tools: [createVirtualReadTool()],
+      virtualStore,
+    };
+
+    const middleware = createWorkspacesMiddleware(options);
+    const wrapToolCall = middleware.wrapToolCall as NonNullable<
+      typeof middleware.wrapToolCall
+    >;
+
+    const result = await wrapToolCall(
+      {
+        toolCall: {
+          id: "e2e-virt-read-1",
+          name: "read_virtual_file",
+          args: { path: "/virtual/docs/readme.md" },
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    expect((result as ToolMessage).content).toBe("# Virtual Hello");
+  });
+
+  test("executes write operation through middleware with virtual mount", async () => {
+    const virtualStore = createBaseStoreLike();
+
+    const options: WorkspacesMiddlewareOptions = {
+      mounts: [
+        {
+          prefix: "/virtual",
+          scope: "READ_WRITE",
+          store: { type: "virtual", namespace: ["workspaces", "test"] },
+        },
+      ],
+      // Include both read and write tools so the tool can be found
+      tools: [createVirtualReadTool(), createVirtualWriteTool()],
+      virtualStore,
+    };
+
+    const middleware = createWorkspacesMiddleware(options);
+    const wrapToolCall = middleware.wrapToolCall as NonNullable<
+      typeof middleware.wrapToolCall
+    >;
+
+    const result = await wrapToolCall(
+      {
+        toolCall: {
+          id: "e2e-virt-write-1",
+          name: "write_virtual_file",
+          args: { path: "/virtual/docs/new.md", content: "# New Virtual Doc" },
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    expect((result as ToolMessage).content).toBe("Virtual file written");
+
+    // Verify data was stored by reading it back
+    const readResult = await wrapToolCall(
+      {
+        toolCall: {
+          id: "e2e-virt-read-2",
+          name: "read_virtual_file",
+          args: { path: "/virtual/docs/new.md" },
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect((readResult as ToolMessage).content).toBe("# New Virtual Doc");
+  });
+
+  test("executes list operation through middleware with virtual mount", async () => {
+    const virtualStore = createBaseStoreLike();
+    const namespace = ["workspaces", "test"];
+
+    // Pre-populate using correct key format
+    await virtualStore.mset([
+      [buildBaseStoreKey(namespace, "docs/a.txt"), "a"],
+      [buildBaseStoreKey(namespace, "docs/b.txt"), "b"],
+      [buildBaseStoreKey(namespace, "other.txt"), "other"],
+    ]);
+
+    const options: WorkspacesMiddlewareOptions = {
+      mounts: [
+        {
+          prefix: "/virtual",
+          scope: "READ_ONLY",
+          store: { type: "virtual", namespace },
+        },
+      ],
+      tools: [createVirtualListTool()],
+      virtualStore,
+    };
+
+    const middleware = createWorkspacesMiddleware(options);
+    const wrapToolCall = middleware.wrapToolCall as NonNullable<
+      typeof middleware.wrapToolCall
+    >;
+
+    const result = await wrapToolCall(
+      {
+        toolCall: {
+          id: "e2e-virt-list-1",
+          name: "list_virtual_files",
+          args: { path: "/virtual/docs" },
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    expect((result as ToolMessage).content).toContain("docs/a.txt");
+    expect((result as ToolMessage).content).toContain("docs/b.txt");
+    // Should not include files from other namespaces
+    expect((result as ToolMessage).content).not.toContain("other.txt");
+  });
+
+  test("unauthorized virtual mount operations return graceful failures", async () => {
+    const virtualStore = createBaseStoreLike();
+
+    const options: WorkspacesMiddlewareOptions = {
+      mounts: [
+        {
+          prefix: "/virtual",
+          scope: "READ_ONLY",
+          store: { type: "virtual", namespace: ["workspaces", "test"] },
+        },
+      ],
+      tools: [createVirtualWriteTool()],
+      virtualStore,
+    };
+
+    const middleware = createWorkspacesMiddleware(options);
+    const wrapToolCall = middleware.wrapToolCall as NonNullable<
+      typeof middleware.wrapToolCall
+    >;
+
+    const result = await wrapToolCall(
+      {
+        toolCall: {
+          id: "e2e-virt-unauth-1",
+          name: "write_virtual_file",
+          args: { path: "/virtual/docs/readme.md", content: "hacked" },
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    expect((result as ToolMessage).content).toContain("not allowed");
+    expect((result as ToolMessage).status).toBe("error");
+  });
+});

--- a/packages/workspaces-middleware/tests/unit/application/tool-synthesizer.test.ts
+++ b/packages/workspaces-middleware/tests/unit/application/tool-synthesizer.test.ts
@@ -64,7 +64,89 @@ describe("tool-synthesizer", () => {
     expect(safe).toHaveLength(0);
   });
 
-  test("enforces resolution and authorization before store access", async () => {
+  test("enforces write operation with READ_WRITE scope", async () => {
+    await mkdir(join(workspaceRoot, "docs"), { recursive: true });
+
+    const mounts: MountConfig[] = [
+      {
+        prefix: "/project",
+        scope: "READ_WRITE",
+        store: { type: "physical", rootDir: workspaceRoot },
+      },
+    ];
+
+    const services = buildVFSServices(mounts);
+
+    const resolved = services.resolve("/project/docs/new.txt");
+    await services.write(resolved.normalizedKey, "new content");
+
+    const content = await readFile(
+      join(workspaceRoot, "docs", "new.txt"),
+      "utf8"
+    );
+    expect(content).toBe("new content");
+  });
+
+  test("enforces list operation with READ_ONLY scope", async () => {
+    await mkdir(join(workspaceRoot, "docs"), { recursive: true });
+    await writeFile(join(workspaceRoot, "docs", "readme.md"), "hello", "utf8");
+    await writeFile(join(workspaceRoot, "docs", "guide.md"), "guide", "utf8");
+
+    const mounts: MountConfig[] = [
+      {
+        prefix: "/project",
+        scope: "READ_ONLY",
+        store: { type: "physical", rootDir: workspaceRoot },
+      },
+    ];
+
+    const services = buildVFSServices(mounts);
+
+    const resolved = services.resolve("/project/docs");
+    const files = await services.list(resolved.normalizedKey);
+
+    expect(files).toContain("docs/readme.md");
+    expect(files).toContain("docs/guide.md");
+  });
+
+  test("enforces stat operation with READ_ONLY scope", async () => {
+    await mkdir(join(workspaceRoot, "docs"), { recursive: true });
+    await writeFile(join(workspaceRoot, "docs", "readme.md"), "hello", "utf8");
+
+    const mounts: MountConfig[] = [
+      {
+        prefix: "/project",
+        scope: "READ_ONLY",
+        store: { type: "physical", rootDir: workspaceRoot },
+      },
+    ];
+
+    const services = buildVFSServices(mounts);
+
+    const resolved = services.resolve("/project/docs/readme.md");
+    const stat = await services.stat(resolved.normalizedKey);
+
+    expect(stat.exists).toBe(true);
+  });
+
+  test("uses in-memory base store for virtual mounts", async () => {
+    const mounts: MountConfig[] = [
+      {
+        prefix: "/virtual",
+        scope: "READ_WRITE",
+        store: { type: "virtual", namespace: ["test", "namespace"] },
+      },
+    ];
+
+    const services = buildVFSServices(mounts);
+
+    await services.write("/virtual/test.txt", "virtual content");
+    const content = await services.read("/virtual/test.txt");
+
+    expect(content).toBe("virtual content");
+  });
+
+  test("rejects ambiguous normalized keys across workspaces", async () => {
     await mkdir(join(workspaceRoot, "docs"), { recursive: true });
     await writeFile(join(workspaceRoot, "docs", "readme.md"), "hello", "utf8");
 

--- a/packages/workspaces-middleware/tests/unit/domain/validate-file-path.test.ts
+++ b/packages/workspaces-middleware/tests/unit/domain/validate-file-path.test.ts
@@ -2,6 +2,31 @@ import { describe, expect, test } from "bun:test";
 
 import { PathTraversalError } from "@/domain/errors";
 import { validateFilePath } from "@/domain/vfs-router";
+import { normalizeStoreKey } from "@/infrastructure/path-utils";
+
+describe("normalizeStoreKey", () => {
+  test("rejects null-byte in path", () => {
+    expect(() => normalizeStoreKey("/project/secret\0.txt")).toThrow(
+      PathTraversalError
+    );
+  });
+
+  test("rejects tilde in path", () => {
+    expect(() => normalizeStoreKey("~/config.json")).toThrow(
+      PathTraversalError
+    );
+  });
+
+  test("allows empty path when allowEmpty is true", () => {
+    const result = normalizeStoreKey(".", true);
+    expect(result).toBe("");
+  });
+
+  test("allows empty string when allowEmpty is true", () => {
+    const result = normalizeStoreKey("", true);
+    expect(result).toBe("");
+  });
+});
 
 describe("validateFilePath", () => {
   test("rejects traversal sequences", () => {

--- a/packages/workspaces-middleware/tests/unit/presentation/middleware.test.ts
+++ b/packages/workspaces-middleware/tests/unit/presentation/middleware.test.ts
@@ -502,4 +502,188 @@ describe("createWorkspacesMiddleware", () => {
     expect(secondMap).toContain("/beta");
     expect(secondMap).not.toContain("/alpha");
   });
+
+  test("passes through to handler when toolName is undefined", async () => {
+    const middleware = createWorkspacesMiddleware({
+      mounts: [
+        {
+          prefix: "/project",
+          scope: "READ_ONLY",
+          store: { type: "physical", rootDir: workspaceRoot },
+        },
+      ],
+      tools: [createReadTool()],
+    });
+
+    const wrapToolCall = middleware.wrapToolCall as NonNullable<
+      typeof middleware.wrapToolCall
+    >;
+
+    let fallbackCalled = false;
+
+    const result = await wrapToolCall(
+      {
+        toolCall: {
+          id: "call-no-name",
+          name: undefined,
+          args: {},
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        fallbackCalled = true;
+        return new ToolMessage({
+          tool_call_id: "call-no-name",
+          content: "fallback result",
+        });
+      }
+    );
+
+    expect(fallbackCalled).toBe(true);
+    expect(result).toBeInstanceOf(ToolMessage);
+    expect((result as ToolMessage).content).toBe("fallback result");
+  });
+
+  test("handles list operation with allowed list/search scope", async () => {
+    const listTool: RegisteredTool = {
+      name: "list_files",
+      description: "List files in workspace",
+      parameters: z.object({ path: z.string() }),
+      operations: ["list"],
+      handler: async (params, services) => {
+        const input = params as { path: string };
+        const resolved = services.resolve(input.path);
+        const files = await services.list(resolved.normalizedKey);
+        return { content: files.join(",") };
+      },
+    };
+
+    const middleware = createWorkspacesMiddleware({
+      mounts: [
+        {
+          prefix: "/project",
+          scope: "READ_WRITE",
+          store: { type: "physical", rootDir: workspaceRoot },
+        },
+      ],
+      tools: [listTool],
+    });
+
+    const wrapToolCall = middleware.wrapToolCall as NonNullable<
+      typeof middleware.wrapToolCall
+    >;
+
+    const result = await wrapToolCall(
+      {
+        toolCall: {
+          id: "call-list",
+          name: "list_files",
+          args: { path: "/project" },
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    expect((result as ToolMessage).content).toContain("docs");
+  });
+
+  test("handles stat operation with various allowed scopes", async () => {
+    const statTool: RegisteredTool = {
+      name: "stat_file",
+      description: "Get file stats",
+      parameters: z.object({ path: z.string() }),
+      operations: ["read", "list", "edit", "search"],
+      handler: async (params, services) => {
+        const input = params as { path: string };
+        const resolved = services.resolve(input.path);
+        const stat = await services.stat(resolved.normalizedKey);
+        return { content: JSON.stringify(stat) };
+      },
+    };
+
+    const middleware = createWorkspacesMiddleware({
+      mounts: [
+        {
+          prefix: "/project",
+          scope: "READ_WRITE",
+          store: { type: "physical", rootDir: workspaceRoot },
+        },
+      ],
+      tools: [statTool],
+    });
+
+    const wrapToolCall = middleware.wrapToolCall as NonNullable<
+      typeof middleware.wrapToolCall
+    >;
+
+    const result = await wrapToolCall(
+      {
+        toolCall: {
+          id: "call-stat",
+          name: "stat_file",
+          args: { path: "/project/docs/readme.md" },
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    expect((result as ToolMessage).content).toContain("exists");
+  });
+
+  test("maps error with message containing 'File not found' to safe message", async () => {
+    const customErrorTool: RegisteredTool = {
+      name: "custom_error_tool",
+      description: "Throws custom error with File not found message",
+      parameters: z.object({}),
+      operations: ["read"],
+      handler: () => {
+        const error = new Error("Custom error: File not found in storage");
+        throw error;
+      },
+    };
+
+    const middleware = createWorkspacesMiddleware({
+      mounts: [
+        {
+          prefix: "/project",
+          scope: "READ_ONLY",
+          store: { type: "physical", rootDir: workspaceRoot },
+        },
+      ],
+      tools: [customErrorTool],
+    });
+
+    const wrapToolCall = middleware.wrapToolCall as NonNullable<
+      typeof middleware.wrapToolCall
+    >;
+
+    const result = await wrapToolCall(
+      {
+        toolCall: {
+          id: "call-custom-error",
+          name: "custom_error_tool",
+          args: {},
+        },
+        runtime: { context: { threadId: "thread-1", runId: "run-1" } },
+        state: { messages: [] },
+      } as never,
+      () => {
+        throw new Error("fallback should not run");
+      }
+    );
+
+    expect(result).toBeInstanceOf(ToolMessage);
+    expect((result as ToolMessage).content).toBe("Error: File not found");
+  });
 });

--- a/packages/workspaces-middleware/tests/unit/presentation/prompt-injector.test.ts
+++ b/packages/workspaces-middleware/tests/unit/presentation/prompt-injector.test.ts
@@ -131,4 +131,100 @@ describe("prompt-injector", () => {
     expect(foreignMessages).toHaveLength(1);
     expect(injectedMaps).toHaveLength(1);
   });
+
+  test("handles undefined messages array", () => {
+    const result = injectFilesystemMap(undefined, mountsTurnOne);
+
+    expect(result).toHaveLength(1);
+    const systemMessage = result[0] as SystemMessage;
+    expect(systemMessage.content).toContain("/alpha");
+  });
+
+  test("handles non-array messages input", () => {
+    const result = injectFilesystemMap("not an array" as never, mountsTurnOne);
+
+    expect(result).toHaveLength(1);
+  });
+
+  test("handles null messages array element", () => {
+    const messages = [null] as unknown[];
+    const result = injectFilesystemMap(messages, mountsTurnOne);
+
+    // Should still inject the filesystem map
+    expect(result).toHaveLength(2);
+  });
+
+  test("handles messages with string type property", () => {
+    const messages = [
+      {
+        type: "system",
+        content: "system message with type property",
+      },
+    ];
+    const result = injectFilesystemMap(messages, mountsTurnOne);
+
+    expect(result).toHaveLength(2);
+  });
+
+  test("handles messages with role property", () => {
+    const messages = [
+      {
+        role: "system",
+        content: "system message with role property",
+      },
+    ];
+    const result = injectFilesystemMap(messages, mountsTurnOne);
+
+    expect(result).toHaveLength(2);
+  });
+
+  test("handles messages with _getType function", () => {
+    const messages = [
+      {
+        _getType: () => "system",
+        content: "system message with _getType",
+      },
+    ];
+    const result = injectFilesystemMap(messages, mountsTurnOne);
+
+    expect(result).toHaveLength(2);
+  });
+
+  test("handles messages with _getType that throws", () => {
+    const messages = [
+      {
+        _getType: () => {
+          throw new Error("getType failed");
+        },
+        content: "message with throwing _getType",
+      },
+    ];
+    const result = injectFilesystemMap(messages, mountsTurnOne);
+
+    // Should treat as non-system and preserve the message
+    expect(result).toHaveLength(2);
+  });
+
+  test("handles message without additional_kwargs", () => {
+    const messages = [
+      {
+        content: "simple message without additional_kwargs",
+      },
+    ];
+    const result = injectFilesystemMap(messages, mountsTurnOne);
+
+    expect(result).toHaveLength(2);
+  });
+
+  test("handles message with null additional_kwargs", () => {
+    const messages = [
+      {
+        content: "message with null additional_kwargs",
+        additional_kwargs: null,
+      },
+    ];
+    const result = injectFilesystemMap(messages, mountsTurnOne);
+
+    expect(result).toHaveLength(2);
+  });
 });


### PR DESCRIPTION
## Summary

- Add E2E tests for physical mount middleware flow (read, write, list, edit operations)
- Add E2E tests for virtual mount middleware flow with LangChain's InMemoryStore
- Add namespace isolation tests for concurrent agent executions with shared virtual stores
- Increase unit test coverage from 93% to **97.19% lines**

### Test Files Added
- `tests/integration/presentation/middleware.e2e.test.ts` - Physical mount E2E tests
- `tests/integration/presentation/middleware.virtual.e2e.test.ts` - Virtual mount E2E tests  
- `tests/integration/presentation/middleware.isolation.e2e.test.ts` - Namespace isolation tests

### Quality Gates
- ✅ Build passes (ESM compatible)
- ✅ Lint clean (26 files)
- ✅ 116 tests pass / 0 fail
- ✅ 97.19% line coverage (target: 80%)