### PR TITLE
Implement ORA Epic C streaming fidelity expansion

### DIFF
--- a/packages/openresponses-adapter/docs/spikes/ORA-C001-truthful-publication-boundaries.md
+++ b/packages/openresponses-adapter/docs/spikes/ORA-C001-truthful-publication-boundaries.md
@@ -1,0 +1,35 @@
+# ORA-C001 Truthful Publication Boundaries
+
+Date: 2026-03-25
+Status: Verified
+
+## Goal
+
+Document which snapshot-required streaming families can be published live from the current LangChain callback surface, and which families must fall back to coarse-live or terminal-summary publication.
+
+## Verified Observation Surfaces
+
+- Raw model text is available from `handleLLMNewToken(token, ...)`.
+- Structured live payloads are available only when LangChain passes a callback chunk. The adapter can inspect:
+  - `fields.chunk.message.contentBlocks`
+  - v1 `message.content`
+  - `additional_kwargs`
+  - tool-call chunk metadata
+- Final structured truth is available from `handleLLMEnd(...)` and `handleAgentEnd(...)`.
+
+## Publication Matrix
+
+| Family | Preferred Mode | Allowed Fallbacks | Truth Source |
+| --- | --- | --- | --- |
+| `output_text` | `live-delta` | `coarse-live` | raw token deltas, finalized output text blocks |
+| `function_call_arguments` | `live-delta` | `coarse-live` | tool-call chunks, agent action deltas, final observed arguments |
+| `reasoning` | `live-delta` | `coarse-live`, `terminal-summary` | LangChain content blocks / v1 output, final structured message |
+| `reasoning_summary` | `coarse-live` | `terminal-summary` | structured summary parts when present, otherwise final reasoning payload |
+| `refusal` | `coarse-live` | `terminal-summary` | refusal blocks or `additional_kwargs.refusal` |
+| `output_text.annotation` | `coarse-live` | `terminal-summary` | annotation arrays on observed output text blocks |
+
+## Rules
+
+- Never fabricate deltas for reasoning, refusal, annotations, or tool arguments.
+- If a family is not exposed live, finish it from the final structured message instead of inventing stream history.
+- `function_call_output` is an output-item family, not a specialized delta family. It is published truthfully only when tool output is actually observed.

--- a/packages/openresponses-adapter/src/callbacks/openresponses-callback-bridge.ts
+++ b/packages/openresponses-adapter/src/callbacks/openresponses-callback-bridge.ts
@@ -10,7 +10,6 @@ export interface OpenResponsesCallbackBridgeOptions {
 }
 
 type RecordValue = Record<string, unknown>;
-
 type TerminalRunStatus = "completed" | "failed";
 
 const MAX_TERMINAL_RUNS = 256;
@@ -249,13 +248,7 @@ const getObservedArguments = (action: unknown): string | undefined => {
     return undefined;
   }
 
-  const directArguments =
-    getString(action, "arguments") ?? getString(action, "args");
-  if (directArguments) {
-    return directArguments;
-  }
-
-  return undefined;
+  return getString(action, "arguments") ?? getString(action, "args");
 };
 
 const getSerializedName = (serialized: RecordValue): string | undefined => {
@@ -294,10 +287,158 @@ const normalizeToolNameFromRun = (
   return getSerializedName(serialized) ?? "tool";
 };
 
+const extractObservedDelta = (
+  previous: string,
+  next: string
+): { delta: string; observed: string } => {
+  if (next.length === 0) {
+    return { delta: "", observed: previous };
+  }
+
+  if (next.startsWith(previous)) {
+    return { delta: next.slice(previous.length), observed: next };
+  }
+
+  return { delta: next, observed: `${previous}${next}` };
+};
+
+const getChunkLike = (...candidates: unknown[]): RecordValue | undefined => {
+  for (const candidate of candidates) {
+    if (!isRecord(candidate)) {
+      continue;
+    }
+
+    const wrappedChunk = candidate.chunk;
+    if (isRecord(wrappedChunk)) {
+      return wrappedChunk;
+    }
+
+    if ("message" in candidate || "content" in candidate || "contentBlocks" in candidate) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+};
+
+const getMessageLike = (value: unknown): RecordValue | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const message = value.message;
+  return isRecord(message) ? message : value;
+};
+
+const getContentBlocks = (value: unknown): RecordValue[] => {
+  const message = getMessageLike(value);
+  if (!message) {
+    return [];
+  }
+
+  const blockCandidates = [message.contentBlocks, message.content];
+  for (const candidate of blockCandidates) {
+    if (!Array.isArray(candidate)) {
+      continue;
+    }
+
+    return candidate.filter(isRecord);
+  }
+
+  return [];
+};
+
+const getAdditionalKwargs = (value: unknown): RecordValue | undefined => {
+  const message = getMessageLike(value);
+  if (!message) {
+    return undefined;
+  }
+
+  return getNestedRecord(message, "additional_kwargs");
+};
+
+const getReasoningTextFromBlock = (block: RecordValue): string | undefined => {
+  if (getString(block, "type") === "reasoning") {
+    return getString(block, "reasoning") ?? getString(block, "text");
+  }
+
+  if (getString(block, "type") === "reasoning_text") {
+    return getString(block, "text");
+  }
+
+  return undefined;
+};
+
+const getSummaryTextFromBlock = (block: RecordValue): string | undefined => {
+  if (getString(block, "type") === "summary_text") {
+    return getString(block, "text");
+  }
+
+  return undefined;
+};
+
+const getRefusalTextFromBlock = (block: RecordValue): string | undefined => {
+  if (getString(block, "type") !== "refusal") {
+    return undefined;
+  }
+
+  return getString(block, "refusal") ?? getString(block, "text");
+};
+
+const extractReasoningSummaryTexts = (value: unknown): string[] => {
+  const blocks = getContentBlocks(value);
+  const summaryTexts = blocks
+    .map(getSummaryTextFromBlock)
+    .filter((text): text is string => Boolean(text));
+  if (summaryTexts.length > 0) {
+    return summaryTexts;
+  }
+
+  const additionalKwargs = getAdditionalKwargs(value);
+  if (!additionalKwargs) {
+    return [];
+  }
+
+  const reasoning = additionalKwargs.reasoning;
+  if (!Array.isArray(reasoning)) {
+    return [];
+  }
+
+  const extracted: string[] = [];
+  for (const candidate of reasoning) {
+    if (!isRecord(candidate)) {
+      continue;
+    }
+
+    const summary = candidate.summary;
+    if (!Array.isArray(summary)) {
+      continue;
+    }
+
+    for (const part of summary) {
+      if (!isRecord(part)) {
+        continue;
+      }
+
+      const summaryText = getString(part, "text");
+      if (summaryText) {
+        extracted.push(summaryText);
+      }
+    }
+  }
+
+  return extracted;
+};
+
 export const createOpenResponsesCallbackBridge = (
   options: OpenResponsesCallbackBridgeOptions
 ): OpenResponsesCallbackHandler => {
   const activeMessageItems = new Map<string, string>();
+  const activeRefusalItems = new Map<string, string>();
+  const activeReasoningItems = new Map<string, string>();
+  const observedRefusalByRun = new Map<string, string>();
+  const observedReasoningByRun = new Map<string, string>();
+  const emittedAnnotationCounts = new Map<string, number>();
   const pendingFunctionCallsByAgentRun = new Map<
     string,
     PendingFunctionCall[]
@@ -309,13 +450,50 @@ export const createOpenResponsesCallbackBridge = (
   const terminalRuns = new Map<string, TerminalRunStatus>();
   const terminalRunOrder: string[] = [];
 
+  const cleanupRunState = (runId: string): void => {
+    activeMessageItems.delete(runId);
+    activeRefusalItems.delete(runId);
+    activeReasoningItems.delete(runId);
+    observedRefusalByRun.delete(runId);
+    observedReasoningByRun.delete(runId);
+    sharedArgumentDeltasByRun.delete(runId);
+
+    const pendingFunctionCalls = pendingFunctionCallsByAgentRun.get(runId);
+    if (pendingFunctionCalls) {
+      for (const pendingFunctionCall of pendingFunctionCalls) {
+        if (pendingFunctionCall.callId) {
+          pendingFunctionCallsByCallId.delete(pendingFunctionCall.callId);
+        }
+
+        if (pendingFunctionCall.toolRunId) {
+          activeFunctionCallsByToolRun.delete(pendingFunctionCall.toolRunId);
+        }
+      }
+
+      pendingFunctionCallsByAgentRun.delete(runId);
+    }
+
+    startedRuns.delete(runId);
+  };
+
+  const rememberTerminalRun = (
+    runId: string,
+    status: TerminalRunStatus
+  ): void => {
+    terminalRuns.set(runId, status);
+    terminalRunOrder.push(runId);
+
+    while (terminalRunOrder.length > MAX_TERMINAL_RUNS) {
+      const oldestRunId = terminalRunOrder.shift();
+      if (oldestRunId) {
+        terminalRuns.delete(oldestRunId);
+      }
+    }
+  };
+
   const emitRunStarted = (runId: string, parentRunId?: string): void => {
     if (terminalRuns.has(runId)) {
       terminalRuns.delete(runId);
-      const terminalRunIndex = terminalRunOrder.indexOf(runId);
-      if (terminalRunIndex >= 0) {
-        terminalRunOrder.splice(terminalRunIndex, 1);
-      }
       cleanupRunState(runId);
     }
 
@@ -341,6 +519,74 @@ export const createOpenResponsesCallbackBridge = (
     activeMessageItems.set(runId, itemId);
     options.emitter.emit({ type: "message.started", itemId, runId });
     return itemId;
+  };
+
+  const ensureRefusalItem = (runId: string): string => {
+    const existing = activeRefusalItems.get(runId);
+    if (existing) {
+      return existing;
+    }
+
+    const itemId = options.generateId();
+    activeRefusalItems.set(runId, itemId);
+    options.emitter.emit({ type: "refusal.started", itemId, runId });
+    return itemId;
+  };
+
+  const ensureReasoningItem = (runId: string): string => {
+    const existing = activeReasoningItems.get(runId);
+    if (existing) {
+      return existing;
+    }
+
+    const itemId = options.generateId();
+    activeReasoningItems.set(runId, itemId);
+    options.emitter.emit({ type: "reasoning.started", itemId, runId });
+    return itemId;
+  };
+
+  const completeActiveMessageArtifacts = (runId: string): void => {
+    const messageItemId = activeMessageItems.get(runId);
+    if (messageItemId) {
+      options.emitter.emit({ type: "text.completed", itemId: messageItemId });
+      activeMessageItems.delete(runId);
+    }
+
+    const refusalItemId = activeRefusalItems.get(runId);
+    if (refusalItemId) {
+      options.emitter.emit({ type: "refusal.completed", itemId: refusalItemId });
+      activeRefusalItems.delete(runId);
+    }
+
+    const reasoningItemId = activeReasoningItems.get(runId);
+    if (reasoningItemId) {
+      options.emitter.emit({
+        type: "reasoning.completed",
+        itemId: reasoningItemId,
+        summaryTexts: extractReasoningSummaryTexts(undefined),
+      });
+      activeReasoningItems.delete(runId);
+    }
+  };
+
+  const emitRunFailed = (runId: string, error: unknown): void => {
+    if (terminalRuns.has(runId)) {
+      return;
+    }
+
+    rememberTerminalRun(runId, "failed");
+    options.emitter.emit({ type: "run.failed", runId, error });
+    cleanupRunState(runId);
+  };
+
+  const emitRunCompleted = (runId: string): void => {
+    if (terminalRuns.has(runId)) {
+      return;
+    }
+
+    rememberTerminalRun(runId, "completed");
+    options.emitter.emit({ type: "run.completed", runId });
+    cleanupRunState(runId);
   };
 
   const getPendingFunctionCalls = (
@@ -436,41 +682,6 @@ export const createOpenResponsesCallbackBridge = (
     });
   };
 
-  const findPendingFunctionCallByCallId = (
-    pendingFunctionCalls: PendingFunctionCall[],
-    toolCallId: string
-  ): PendingFunctionCall | undefined => {
-    const matchedByCallId = pendingFunctionCallsByCallId.get(toolCallId);
-    if (matchedByCallId && pendingFunctionCalls.includes(matchedByCallId)) {
-      return matchedByCallId;
-    }
-
-    return undefined;
-  };
-
-  const findPendingFunctionCallByToolName = (
-    pendingFunctionCalls: PendingFunctionCall[],
-    toolName: string,
-    toolCallId?: string
-  ): PendingFunctionCall | undefined => {
-    for (const pendingFunctionCall of pendingFunctionCalls) {
-      if (pendingFunctionCall.toolName !== toolName) {
-        continue;
-      }
-
-      if (
-        toolCallId !== undefined &&
-        pendingFunctionCall.callId !== undefined
-      ) {
-        continue;
-      }
-
-      return pendingFunctionCall;
-    }
-
-    return undefined;
-  };
-
   const resolvePendingFunctionCallForToolStart = (
     agentRunId: string,
     toolName: string,
@@ -482,25 +693,17 @@ export const createOpenResponsesCallbackBridge = (
     }
 
     if (toolCallId) {
-      const matchedByCallId = findPendingFunctionCallByCallId(
-        pendingFunctionCalls,
-        toolCallId
-      );
-      if (matchedByCallId) {
+      const matchedByCallId = pendingFunctionCallsByCallId.get(toolCallId);
+      if (matchedByCallId && pendingFunctionCalls.includes(matchedByCallId)) {
         return matchedByCallId;
       }
     }
 
-    const matchedByToolName = findPendingFunctionCallByToolName(
-      pendingFunctionCalls,
-      toolName,
-      toolCallId
+    return (
+      pendingFunctionCalls.find((pendingFunctionCall) => {
+        return pendingFunctionCall.toolName === toolName;
+      }) ?? pendingFunctionCalls[0]
     );
-    if (matchedByToolName) {
-      return matchedByToolName;
-    }
-
-    return pendingFunctionCalls[0];
   };
 
   const resolvePendingFunctionCallForToolEnd = (
@@ -521,26 +724,8 @@ export const createOpenResponsesCallbackBridge = (
       return undefined;
     }
 
-    for (const pendingFunctionCall of pendingFunctionCalls) {
-      if (pendingFunctionCall.startedEmitted) {
-        return pendingFunctionCall;
-      }
-    }
-
-    return pendingFunctionCalls[0];
-  };
-
-  const completeFunctionCall = (
-    pendingFunctionCall: PendingFunctionCall | undefined
-  ): void => {
-    if (!pendingFunctionCall) {
-      return;
-    }
-
-    options.emitter.emit({
-      type: "function_call.completed",
-      itemId: pendingFunctionCall.itemId,
-    });
+    return pendingFunctionCalls.find((candidate) => candidate.startedEmitted)
+      ?? pendingFunctionCalls[0];
   };
 
   const cleanupFunctionCallState = (
@@ -581,66 +766,108 @@ export const createOpenResponsesCallbackBridge = (
     pendingFunctionCallsByAgentRun.set(agentRunId, remaining);
   };
 
-  const cleanupRunState = (runId: string): void => {
-    activeMessageItems.delete(runId);
-    sharedArgumentDeltasByRun.delete(runId);
+  const emitObservedRefusal = (runId: string, refusal: string): void => {
+    const itemId = ensureRefusalItem(runId);
+    const previous = observedRefusalByRun.get(runId) ?? "";
+    const { delta, observed } = extractObservedDelta(previous, refusal);
+    observedRefusalByRun.set(runId, observed);
+    if (delta.length > 0) {
+      options.emitter.emit({ type: "refusal.delta", itemId, delta });
+    }
+  };
 
-    const pendingFunctionCalls = pendingFunctionCallsByAgentRun.get(runId);
-    if (pendingFunctionCalls) {
-      for (const pendingFunctionCall of pendingFunctionCalls) {
-        if (pendingFunctionCall.callId) {
-          pendingFunctionCallsByCallId.delete(pendingFunctionCall.callId);
-        }
+  const emitObservedReasoning = (runId: string, reasoning: string): void => {
+    const itemId = ensureReasoningItem(runId);
+    const previous = observedReasoningByRun.get(runId) ?? "";
+    const { delta, observed } = extractObservedDelta(previous, reasoning);
+    observedReasoningByRun.set(runId, observed);
+    if (delta.length > 0) {
+      options.emitter.emit({ type: "reasoning.delta", itemId, delta });
+    }
+  };
 
-        if (pendingFunctionCall.toolRunId) {
-          activeFunctionCallsByToolRun.delete(pendingFunctionCall.toolRunId);
-        }
+  const emitObservedAnnotations = (runId: string, blocks: RecordValue[]): void => {
+    const messageItemId = activeMessageItems.get(runId);
+    if (!messageItemId) {
+      return;
+    }
+
+    const outputTextBlock = blocks.find((block) => {
+      return getString(block, "type") === "output_text";
+    });
+    if (!outputTextBlock) {
+      return;
+    }
+
+    const annotations = outputTextBlock.annotations;
+    if (!Array.isArray(annotations)) {
+      return;
+    }
+
+    const emittedCount = emittedAnnotationCounts.get(messageItemId) ?? 0;
+    for (const annotation of annotations.slice(emittedCount)) {
+      if (!isRecord(annotation)) {
+        continue;
       }
 
-      pendingFunctionCallsByAgentRun.delete(runId);
+      options.emitter.emit({
+        type: "output_text.annotation.added",
+        itemId: messageItemId,
+        annotation,
+      });
     }
 
-    startedRuns.delete(runId);
+    emittedAnnotationCounts.set(messageItemId, annotations.length);
   };
 
-  const rememberTerminalRun = (
-    runId: string,
-    status: TerminalRunStatus
-  ): void => {
-    if (terminalRuns.has(runId)) {
-      terminalRuns.set(runId, status);
+  const observeChunk = (runId: string, ...candidates: unknown[]): void => {
+    const chunk = getChunkLike(...candidates);
+    if (!chunk) {
       return;
     }
 
-    terminalRuns.set(runId, status);
-    terminalRunOrder.push(runId);
+    const contentBlocks = getContentBlocks(chunk);
+    emitObservedAnnotations(runId, contentBlocks);
 
-    while (terminalRunOrder.length > MAX_TERMINAL_RUNS) {
-      const oldestRunId = terminalRunOrder.shift();
-      if (oldestRunId) {
-        terminalRuns.delete(oldestRunId);
+    for (const block of contentBlocks) {
+      const refusal = getRefusalTextFromBlock(block);
+      if (refusal) {
+        emitObservedRefusal(runId, refusal);
+      }
+
+      const reasoning = getReasoningTextFromBlock(block);
+      if (reasoning) {
+        emitObservedReasoning(runId, reasoning);
+      }
+    }
+
+    const additionalKwargs = getAdditionalKwargs(chunk);
+    if (additionalKwargs) {
+      const refusal = additionalKwargs.refusal;
+      if (typeof refusal === "string") {
+        emitObservedRefusal(runId, refusal);
       }
     }
   };
 
-  const emitRunFailed = (runId: string, error: unknown): void => {
-    if (terminalRuns.has(runId)) {
-      return;
+  const finalizeObservedFamilies = (runId: string, output?: unknown): void => {
+    observeChunk(runId, output);
+
+    const refusalItemId = activeRefusalItems.get(runId);
+    if (refusalItemId) {
+      options.emitter.emit({ type: "refusal.completed", itemId: refusalItemId });
+      activeRefusalItems.delete(runId);
     }
 
-    rememberTerminalRun(runId, "failed");
-    options.emitter.emit({ type: "run.failed", runId, error });
-    cleanupRunState(runId);
-  };
-
-  const emitRunCompleted = (runId: string): void => {
-    if (terminalRuns.has(runId)) {
-      return;
+    const reasoningItemId = activeReasoningItems.get(runId);
+    if (reasoningItemId) {
+      options.emitter.emit({
+        type: "reasoning.completed",
+        itemId: reasoningItemId,
+        summaryTexts: extractReasoningSummaryTexts(output),
+      });
+      activeReasoningItems.delete(runId);
     }
-
-    rememberTerminalRun(runId, "completed");
-    options.emitter.emit({ type: "run.completed", runId });
-    cleanupRunState(runId);
   };
 
   return {
@@ -648,17 +875,25 @@ export const createOpenResponsesCallbackBridge = (
       emitRunStarted(runId, parentRunId);
     },
 
-    handleLLMNewToken(token, _chunk, runId): void {
-      const itemId = ensureMessageItem(runId);
-      options.emitter.emit({ type: "text.delta", itemId, delta: token });
+    handleLLMNewToken(token, idxOrChunk, runId, parentRunId, tags, fields): void {
+      emitRunStarted(runId, parentRunId);
+
+      if (token.length > 0) {
+        const itemId = ensureMessageItem(runId);
+        options.emitter.emit({ type: "text.delta", itemId, delta: token });
+      }
+
+      observeChunk(runId, idxOrChunk, fields, tags);
     },
 
-    handleLLMEnd(_output, runId): void {
+    handleLLMEnd(output, runId): void {
       const itemId = activeMessageItems.get(runId);
       if (itemId) {
         options.emitter.emit({ type: "text.completed", itemId });
+        activeMessageItems.delete(runId);
       }
 
+      finalizeObservedFamilies(runId, output);
       emitRunCompleted(runId);
     },
 
@@ -718,7 +953,26 @@ export const createOpenResponsesCallbackBridge = (
             }
           : { type: "tool.completed", runId, output }
       );
-      completeFunctionCall(pendingFunctionCall);
+
+      if (pendingFunctionCall) {
+        options.emitter.emit({
+          type: "function_call.completed",
+          itemId: pendingFunctionCall.itemId,
+        });
+
+        if (pendingFunctionCall.callId) {
+          options.emitter.emit({
+            type: "function_call_output.completed",
+            itemId: options.generateId(),
+            callId: pendingFunctionCall.callId,
+            output:
+              typeof output === "string"
+                ? output
+                : safeStringify(output),
+          });
+        }
+      }
+
       cleanupFunctionCallState(pendingFunctionCall, parentRunId, runId);
     },
 
@@ -728,7 +982,12 @@ export const createOpenResponsesCallbackBridge = (
         runId,
         parentRunId
       );
-      completeFunctionCall(pendingFunctionCall);
+      if (pendingFunctionCall) {
+        options.emitter.emit({
+          type: "function_call.completed",
+          itemId: pendingFunctionCall.itemId,
+        });
+      }
       cleanupFunctionCallState(pendingFunctionCall, parentRunId, runId);
     },
 
@@ -756,7 +1015,14 @@ export const createOpenResponsesCallbackBridge = (
       }
     },
 
-    handleAgentEnd(_result, runId): void {
+    handleAgentEnd(result, runId): void {
+      const itemId = activeMessageItems.get(runId);
+      if (itemId) {
+        options.emitter.emit({ type: "text.completed", itemId });
+        activeMessageItems.delete(runId);
+      }
+
+      finalizeObservedFamilies(runId, result);
       emitRunCompleted(runId);
     },
 

--- a/packages/openresponses-adapter/src/callbacks/openresponses-callback-bridge.ts
+++ b/packages/openresponses-adapter/src/callbacks/openresponses-callback-bridge.ts
@@ -313,7 +313,11 @@ const getChunkLike = (...candidates: unknown[]): RecordValue | undefined => {
       return wrappedChunk;
     }
 
-    if ("message" in candidate || "content" in candidate || "contentBlocks" in candidate) {
+    if (
+      "message" in candidate ||
+      "content" in candidate ||
+      "contentBlocks" in candidate
+    ) {
       return candidate;
     }
   }
@@ -554,7 +558,10 @@ export const createOpenResponsesCallbackBridge = (
 
     const refusalItemId = activeRefusalItems.get(runId);
     if (refusalItemId) {
-      options.emitter.emit({ type: "refusal.completed", itemId: refusalItemId });
+      options.emitter.emit({
+        type: "refusal.completed",
+        itemId: refusalItemId,
+      });
       activeRefusalItems.delete(runId);
     }
 
@@ -699,11 +706,9 @@ export const createOpenResponsesCallbackBridge = (
       }
     }
 
-    return (
-      pendingFunctionCalls.find((pendingFunctionCall) => {
-        return pendingFunctionCall.toolName === toolName;
-      }) ?? pendingFunctionCalls[0]
-    );
+    return pendingFunctionCalls.find((pendingFunctionCall) => {
+      return pendingFunctionCall.toolName === toolName;
+    });
   };
 
   const resolvePendingFunctionCallForToolEnd = (
@@ -724,8 +729,7 @@ export const createOpenResponsesCallbackBridge = (
       return undefined;
     }
 
-    return pendingFunctionCalls.find((candidate) => candidate.startedEmitted)
-      ?? pendingFunctionCalls[0];
+    return pendingFunctionCalls.find((candidate) => candidate.startedEmitted);
   };
 
   const cleanupFunctionCallState = (
@@ -786,7 +790,10 @@ export const createOpenResponsesCallbackBridge = (
     }
   };
 
-  const emitObservedAnnotations = (runId: string, blocks: RecordValue[]): void => {
+  const emitObservedAnnotations = (
+    runId: string,
+    blocks: RecordValue[]
+  ): void => {
     const messageItemId = activeMessageItems.get(runId);
     if (!messageItemId) {
       return;
@@ -855,7 +862,10 @@ export const createOpenResponsesCallbackBridge = (
 
     const refusalItemId = activeRefusalItems.get(runId);
     if (refusalItemId) {
-      options.emitter.emit({ type: "refusal.completed", itemId: refusalItemId });
+      options.emitter.emit({
+        type: "refusal.completed",
+        itemId: refusalItemId,
+      });
       activeRefusalItems.delete(runId);
     }
 
@@ -875,7 +885,14 @@ export const createOpenResponsesCallbackBridge = (
       emitRunStarted(runId, parentRunId);
     },
 
-    handleLLMNewToken(token, idxOrChunk, runId, parentRunId, tags, fields): void {
+    handleLLMNewToken(
+      token,
+      idxOrChunk,
+      runId,
+      parentRunId,
+      tags,
+      fields
+    ): void {
       emitRunStarted(runId, parentRunId);
 
       if (token.length > 0) {
@@ -965,10 +982,7 @@ export const createOpenResponsesCallbackBridge = (
             type: "function_call_output.completed",
             itemId: options.generateId(),
             callId: pendingFunctionCall.callId,
-            output:
-              typeof output === "string"
-                ? output
-                : safeStringify(output),
+            output: typeof output === "string" ? output : safeStringify(output),
           });
         }
       }

--- a/packages/openresponses-adapter/src/callbacks/openresponses-callback-bridge.ts
+++ b/packages/openresponses-adapter/src/callbacks/openresponses-callback-bridge.ts
@@ -498,6 +498,10 @@ export const createOpenResponsesCallbackBridge = (
   const emitRunStarted = (runId: string, parentRunId?: string): void => {
     if (terminalRuns.has(runId)) {
       terminalRuns.delete(runId);
+      const terminalRunIndex = terminalRunOrder.indexOf(runId);
+      if (terminalRunIndex >= 0) {
+        terminalRunOrder.splice(terminalRunIndex, 1);
+      }
       cleanupRunState(runId);
     }
 
@@ -547,33 +551,6 @@ export const createOpenResponsesCallbackBridge = (
     activeReasoningItems.set(runId, itemId);
     options.emitter.emit({ type: "reasoning.started", itemId, runId });
     return itemId;
-  };
-
-  const completeActiveMessageArtifacts = (runId: string): void => {
-    const messageItemId = activeMessageItems.get(runId);
-    if (messageItemId) {
-      options.emitter.emit({ type: "text.completed", itemId: messageItemId });
-      activeMessageItems.delete(runId);
-    }
-
-    const refusalItemId = activeRefusalItems.get(runId);
-    if (refusalItemId) {
-      options.emitter.emit({
-        type: "refusal.completed",
-        itemId: refusalItemId,
-      });
-      activeRefusalItems.delete(runId);
-    }
-
-    const reasoningItemId = activeReasoningItems.get(runId);
-    if (reasoningItemId) {
-      options.emitter.emit({
-        type: "reasoning.completed",
-        itemId: reasoningItemId,
-        summaryTexts: extractReasoningSummaryTexts(undefined),
-      });
-      activeReasoningItems.delete(runId);
-    }
   };
 
   const emitRunFailed = (runId: string, error: unknown): void => {

--- a/packages/openresponses-adapter/src/contract/field-policy.ts
+++ b/packages/openresponses-adapter/src/contract/field-policy.ts
@@ -10,6 +10,13 @@ export type TruthfulPublicationMode =
   | "coarse-live"
   | "terminal-summary";
 
+export interface TruthfulPublicationPolicyEntry {
+  family: string;
+  preferred: TruthfulPublicationMode;
+  fallbacks: TruthfulPublicationMode[];
+  notes: string;
+}
+
 export interface ContractFieldPolicyEntry {
   field: string;
   policy: ContractFieldPolicy;
@@ -49,10 +56,47 @@ export const terminalResponseFieldPolicy: ContractFieldPolicyEntry[] = [
   },
 ] as const;
 
-export const truthfulPublicationModes = {
-  function_call_arguments: "live-delta",
-  output_text: "live-delta",
-  reasoning: "terminal-summary",
-  reasoning_summary: "terminal-summary",
-  refusal: "terminal-summary",
-} as const satisfies Record<string, TruthfulPublicationMode>;
+export const truthfulPublicationPolicies: TruthfulPublicationPolicyEntry[] = [
+  {
+    family: "output_text",
+    preferred: "live-delta",
+    fallbacks: ["coarse-live"],
+    notes:
+      "Use raw token deltas when present; only fall back to coarse completion when the runtime exposes final text but not token chunks.",
+  },
+  {
+    family: "function_call_arguments",
+    preferred: "live-delta",
+    fallbacks: ["coarse-live"],
+    notes:
+      "Use observed tool-call chunks or action/message-log deltas; fall back to done-only publication when only final arguments are available.",
+  },
+  {
+    family: "reasoning",
+    preferred: "live-delta",
+    fallbacks: ["coarse-live", "terminal-summary"],
+    notes:
+      "Use LangChain chunk contentBlocks/v1 content when reasoning is exposed live; otherwise complete from final message truth without fabricating deltas.",
+  },
+  {
+    family: "reasoning_summary",
+    preferred: "coarse-live",
+    fallbacks: ["terminal-summary"],
+    notes:
+      "Publish live only when structured summary parts are observed; otherwise include the summary only on final reasoning items.",
+  },
+  {
+    family: "refusal",
+    preferred: "coarse-live",
+    fallbacks: ["terminal-summary"],
+    notes:
+      "Publish from observed refusal blocks or additional_kwargs, but never invent refusal deltas from plain text.",
+  },
+  {
+    family: "output_text.annotation",
+    preferred: "coarse-live",
+    fallbacks: ["terminal-summary"],
+    notes:
+      "Emit annotations when they first appear on observed output_text blocks; otherwise leave them only on the finalized output text part.",
+  },
+] as const;

--- a/packages/openresponses-adapter/src/core/events.ts
+++ b/packages/openresponses-adapter/src/core/events.ts
@@ -1,70 +1,96 @@
 /**
- * Internal Semantic Event Types
+ * Internal semantic event types consumed by the serializer.
  *
- * These events are emitted by the callback bridge and consumed
- * by the accumulator and serializer. They are internal to the adapter
- * and map to Open Responses public events.
+ * These events are derived from LangChain callbacks but remain provider-agnostic.
  */
 
-/**
- * Union of all internal semantic events.
- * These derive from LangChain callbacks and are transformed into
- * Open Responses public events by the serializer.
- */
 export type InternalSemanticEvent =
   | RunStartedEvent
   | MessageStartedEvent
   | TextDeltaEvent
   | TextCompletedEvent
+  | RefusalStartedEvent
+  | RefusalDeltaEvent
+  | RefusalCompletedEvent
+  | ReasoningStartedEvent
+  | ReasoningDeltaEvent
+  | ReasoningCompletedEvent
+  | OutputTextAnnotationAddedEvent
   | FunctionCallStartedEvent
   | FunctionCallArgumentsDeltaEvent
   | FunctionCallCompletedEvent
+  | FunctionCallOutputCompletedEvent
   | ToolStartedEvent
   | ToolCompletedEvent
   | ToolErrorEvent
   | RunCompletedEvent
-  | RunFailedEvent;
+  | RunFailedEvent
+  | RunIncompleteEvent;
 
-/**
- * Agent/chain run started.
- */
 export interface RunStartedEvent {
   type: "run.started";
   runId: string;
   parentRunId?: string;
 }
 
-/**
- * Assistant message item started.
- */
 export interface MessageStartedEvent {
   type: "message.started";
   itemId: string;
   runId: string;
 }
 
-/**
- * Text delta for streaming output.
- */
 export interface TextDeltaEvent {
   type: "text.delta";
   itemId: string;
   delta: string;
 }
 
-/**
- * Text content completed.
- */
 export interface TextCompletedEvent {
   type: "text.completed";
   itemId: string;
 }
 
-/**
- * Function call (tool use) started.
- * When provider granularity is weak, the full arguments may be attached here
- * so downstream state can emit done-only behavior without synthetic deltas.
- */
+export interface RefusalStartedEvent {
+  type: "refusal.started";
+  itemId: string;
+  runId: string;
+}
+
+export interface RefusalDeltaEvent {
+  type: "refusal.delta";
+  itemId: string;
+  delta: string;
+}
+
+export interface RefusalCompletedEvent {
+  type: "refusal.completed";
+  itemId: string;
+}
+
+export interface ReasoningStartedEvent {
+  type: "reasoning.started";
+  itemId: string;
+  runId: string;
+}
+
+export interface ReasoningDeltaEvent {
+  type: "reasoning.delta";
+  itemId: string;
+  delta: string;
+}
+
+export interface ReasoningCompletedEvent {
+  type: "reasoning.completed";
+  itemId: string;
+  summaryTexts?: string[];
+}
+
+export interface OutputTextAnnotationAddedEvent {
+  type: "output_text.annotation.added";
+  itemId: string;
+  annotation: Record<string, unknown>;
+}
+
 export interface FunctionCallStartedEvent {
   type: "function_call.started";
   itemId: string;
@@ -73,26 +99,24 @@ export interface FunctionCallStartedEvent {
   arguments?: string;
 }
 
-/**
- * Function call arguments delta.
- */
 export interface FunctionCallArgumentsDeltaEvent {
   type: "function_call_arguments.delta";
   itemId: string;
   delta: string;
 }
 
-/**
- * Function call completed.
- */
 export interface FunctionCallCompletedEvent {
   type: "function_call.completed";
   itemId: string;
 }
 
-/**
- * Tool execution started.
- */
+export interface FunctionCallOutputCompletedEvent {
+  type: "function_call_output.completed";
+  itemId: string;
+  callId: string;
+  output: string | Record<string, unknown>[];
+}
+
 export interface ToolStartedEvent {
   type: "tool.started";
   runId: string;
@@ -100,9 +124,6 @@ export interface ToolStartedEvent {
   input: string;
 }
 
-/**
- * Tool execution completed.
- */
 export interface ToolCompletedEvent {
   type: "tool.completed";
   runId: string;
@@ -110,40 +131,31 @@ export interface ToolCompletedEvent {
   callId?: string;
 }
 
-/**
- * Tool execution error.
- */
 export interface ToolErrorEvent {
   type: "tool.error";
   runId: string;
   error: unknown;
 }
 
-/**
- * Run/agent completed successfully.
- */
 export interface RunCompletedEvent {
   type: "run.completed";
   runId: string;
 }
 
-/**
- * Run/agent failed with error.
- */
 export interface RunFailedEvent {
   type: "run.failed";
   runId: string;
   error: unknown;
 }
 
-/**
- * Event emitter interface for callback handlers.
- */
+export interface RunIncompleteEvent {
+  type: "run.incomplete";
+  runId: string;
+  reason?: string;
+}
+
 export interface InternalEventEmitter {
   emit(event: InternalSemanticEvent): void;
 }
 
-/**
- * Event listener interface for consumers.
- */
 export type InternalEventListener = (event: InternalSemanticEvent) => void;

--- a/packages/openresponses-adapter/src/core/tool-policy.ts
+++ b/packages/openresponses-adapter/src/core/tool-policy.ts
@@ -3,7 +3,7 @@ import {
   FunctionToolSchema,
   type ToolChoice,
   ToolChoiceSchema,
-} from "./internal-schemas.js";
+} from "./schemas.js";
 import type { NormalizedToolPolicy } from "./types.js";
 
 export type EffectiveToolChoiceMode = "none" | "auto" | "required";

--- a/packages/openresponses-adapter/src/core/types.ts
+++ b/packages/openresponses-adapter/src/core/types.ts
@@ -12,8 +12,8 @@ import type {
   FunctionTool,
   InputItem,
   OpenResponsesEvent,
-  ToolChoice,
   OpenResponsesResponse,
+  ToolChoice,
 } from "./schemas.js";
 
 // =============================================================================

--- a/packages/openresponses-adapter/src/core/types.ts
+++ b/packages/openresponses-adapter/src/core/types.ts
@@ -13,8 +13,8 @@ import type {
   InputItem,
   OpenResponsesEvent,
   ToolChoice,
-} from "./internal-schemas.js";
-import type { OpenResponsesResponse } from "./schemas.js";
+  OpenResponsesResponse,
+} from "./schemas.js";
 
 // =============================================================================
 // Persistence Types

--- a/packages/openresponses-adapter/src/server/adapter.ts
+++ b/packages/openresponses-adapter/src/server/adapter.ts
@@ -21,8 +21,9 @@ import type {
   OpenResponsesRequestSnapshot,
   PreviousResponseStore,
 } from "@/core/index.js";
-import type { InputItem, OpenResponsesEvent } from "@/core/internal-schemas.js";
 import type {
+  InputItem,
+  OpenResponsesEvent,
   OpenResponsesRequest,
   OpenResponsesResponse,
 } from "@/core/schemas.js";
@@ -513,6 +514,7 @@ export function createOpenResponsesAdapter(
         queue,
         accumulator,
         lifecycle,
+        request: normalizedRequest.requestSnapshot,
         responseId,
       });
 

--- a/packages/openresponses-adapter/src/server/event-serializer.ts
+++ b/packages/openresponses-adapter/src/server/event-serializer.ts
@@ -128,7 +128,10 @@ const getOutputIndexOrThrow = (
   return outputIndex;
 };
 
-const nextOutputIndex = (context: SerializerContext, itemId: string): number => {
+const nextOutputIndex = (
+  context: SerializerContext,
+  itemId: string
+): number => {
   const outputIndex = context.itemOutputIndices.size;
   context.itemOutputIndices.set(itemId, outputIndex);
   return outputIndex;
@@ -185,7 +188,9 @@ export const serializeInternalEvent = (
     }
 
     case "message.started": {
-      const item = context.accumulator.startTextMessageItem({ id: event.itemId });
+      const item = context.accumulator.startTextMessageItem({
+        id: event.itemId,
+      });
       const outputIndex = nextOutputIndex(context, event.itemId);
       const events: OpenResponsesEvent[] = [];
       const inProgressEvent = ensureInProgressEvent(context);
@@ -206,7 +211,9 @@ export const serializeInternalEvent = (
           item_id: event.itemId,
           output_index: outputIndex,
           content_index: 0,
-          part: item.content[0] as OpenResponsesEvent extends never ? never : any,
+          part: item.content[0] as OpenResponsesEvent extends never
+            ? never
+            : any,
         }
       );
 
@@ -214,7 +221,11 @@ export const serializeInternalEvent = (
     }
 
     case "text.delta": {
-      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+      const outputIndex = getOutputIndexOrThrow(
+        context,
+        event.itemId,
+        event.type
+      );
       context.accumulator.appendOutputTextDelta(event.itemId, event.delta);
       return [
         {
@@ -230,7 +241,11 @@ export const serializeInternalEvent = (
     }
 
     case "text.completed": {
-      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+      const outputIndex = getOutputIndexOrThrow(
+        context,
+        event.itemId,
+        event.type
+      );
       const finalizedItem = context.accumulator.finalizeMessageItem(
         event.itemId,
         "completed"
@@ -271,7 +286,9 @@ export const serializeInternalEvent = (
     }
 
     case "refusal.started": {
-      const item = context.accumulator.startRefusalMessageItem({ id: event.itemId });
+      const item = context.accumulator.startRefusalMessageItem({
+        id: event.itemId,
+      });
       const outputIndex = nextOutputIndex(context, event.itemId);
       const events: OpenResponsesEvent[] = [];
       const inProgressEvent = ensureInProgressEvent(context);
@@ -292,7 +309,9 @@ export const serializeInternalEvent = (
           item_id: event.itemId,
           output_index: outputIndex,
           content_index: 0,
-          part: item.content[0] as OpenResponsesEvent extends never ? never : any,
+          part: item.content[0] as OpenResponsesEvent extends never
+            ? never
+            : any,
         }
       );
 
@@ -300,7 +319,11 @@ export const serializeInternalEvent = (
     }
 
     case "refusal.delta": {
-      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+      const outputIndex = getOutputIndexOrThrow(
+        context,
+        event.itemId,
+        event.type
+      );
       context.accumulator.appendRefusalDelta(event.itemId, event.delta);
       return [
         {
@@ -315,7 +338,11 @@ export const serializeInternalEvent = (
     }
 
     case "refusal.completed": {
-      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+      const outputIndex = getOutputIndexOrThrow(
+        context,
+        event.itemId,
+        event.type
+      );
       const finalizedItem = context.accumulator.finalizeMessageItem(
         event.itemId,
         "completed"
@@ -384,7 +411,11 @@ export const serializeInternalEvent = (
     }
 
     case "reasoning.delta": {
-      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+      const outputIndex = getOutputIndexOrThrow(
+        context,
+        event.itemId,
+        event.type
+      );
       context.accumulator.appendReasoningDelta(event.itemId, event.delta);
       return [
         {
@@ -399,11 +430,17 @@ export const serializeInternalEvent = (
     }
 
     case "reasoning.completed": {
-      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+      const outputIndex = getOutputIndexOrThrow(
+        context,
+        event.itemId,
+        event.type
+      );
       for (const summaryText of event.summaryTexts ?? []) {
         context.accumulator.appendReasoningSummary(event.itemId, summaryText);
       }
-      const finalizedItem = context.accumulator.finalizeReasoningItem(event.itemId);
+      const finalizedItem = context.accumulator.finalizeReasoningItem(
+        event.itemId
+      );
       const reasoningText = finalizedItem.content?.[0];
       if (!reasoningText || reasoningText.type !== "reasoning_text") {
         throw new Error(
@@ -438,8 +475,15 @@ export const serializeInternalEvent = (
     }
 
     case "output_text.annotation.added": {
-      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
-      context.accumulator.addOutputTextAnnotation(event.itemId, event.annotation);
+      const outputIndex = getOutputIndexOrThrow(
+        context,
+        event.itemId,
+        event.type
+      );
+      context.accumulator.addOutputTextAnnotation(
+        event.itemId,
+        event.annotation
+      );
       const item = context.accumulator.snapshot().find((candidate) => {
         return candidate.type === "message" && candidate.id === event.itemId;
       });
@@ -470,24 +514,31 @@ export const serializeInternalEvent = (
         id: event.itemId,
         name: event.name,
         callId: event.callId,
-        ...(event.arguments !== undefined ? { arguments: event.arguments } : {}),
+        ...(event.arguments !== undefined
+          ? { arguments: event.arguments }
+          : {}),
       });
       const outputIndex = nextOutputIndex(context, event.itemId);
-      events.push(
-        {
-          type: "response.output_item.added",
-          sequence_number: context.sequence.next(),
-          output_index: outputIndex,
-          item,
-        }
-      );
+      events.push({
+        type: "response.output_item.added",
+        sequence_number: context.sequence.next(),
+        output_index: outputIndex,
+        item,
+      });
 
       return events;
     }
 
     case "function_call_arguments.delta": {
-      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
-      context.accumulator.appendFunctionCallArgumentsDelta(event.itemId, event.delta);
+      const outputIndex = getOutputIndexOrThrow(
+        context,
+        event.itemId,
+        event.type
+      );
+      context.accumulator.appendFunctionCallArgumentsDelta(
+        event.itemId,
+        event.delta
+      );
       return [
         {
           type: "response.function_call_arguments.delta",
@@ -500,7 +551,11 @@ export const serializeInternalEvent = (
     }
 
     case "function_call.completed": {
-      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+      const outputIndex = getOutputIndexOrThrow(
+        context,
+        event.itemId,
+        event.type
+      );
       const finalizedItem = context.accumulator.finalizeFunctionCallItem(
         event.itemId,
         "completed"

--- a/packages/openresponses-adapter/src/server/event-serializer.ts
+++ b/packages/openresponses-adapter/src/server/event-serializer.ts
@@ -20,6 +20,24 @@ import type { CanonicalItemAccumulator } from "@/state/item-accumulator.js";
 import { materializeResponseSnapshot } from "@/state/response-aggregate.js";
 import type { ResponseLifecycle } from "@/state/response-lifecycle.js";
 
+type ContentPartEventPart = Extract<
+  OpenResponsesEvent,
+  { type: "response.content_part.added" }
+>["part"];
+type OutputTextContentPart = Extract<
+  ContentPartEventPart,
+  { type: "output_text" }
+>;
+type RefusalContentPart = Extract<ContentPartEventPart, { type: "refusal" }>;
+
+type LifecycleEventType =
+  | "response.created"
+  | "response.queued"
+  | "response.in_progress"
+  | "response.completed"
+  | "response.failed"
+  | "response.incomplete";
+
 export const createSequenceGenerator = (): SequenceGenerator => {
   let counter = 0;
   return {
@@ -137,6 +155,22 @@ const nextOutputIndex = (
   return outputIndex;
 };
 
+const emitLifecycleEvent = (
+  type: LifecycleEventType,
+  context: SerializerContext,
+  status: OpenResponsesResponse["status"],
+  overrides?: {
+    error?: OpenResponsesResponse["error"];
+    incompleteDetails?: OpenResponsesResponse["incomplete_details"];
+  }
+): OpenResponsesEvent => {
+  return {
+    type,
+    sequence_number: context.sequence.next(),
+    response: buildResponseSnapshot(context, status, overrides),
+  } as OpenResponsesEvent;
+};
+
 const ensureInProgressEvent = (
   context: SerializerContext
 ): OpenResponsesEvent | null => {
@@ -155,26 +189,505 @@ const ensureInProgressEvent = (
   return emitLifecycleEvent("response.in_progress", context, "in_progress");
 };
 
-const emitLifecycleEvent = (
-  type:
-    | "response.created"
-    | "response.queued"
-    | "response.in_progress"
-    | "response.completed"
-    | "response.failed"
-    | "response.incomplete",
-  context: SerializerContext,
-  status: OpenResponsesResponse["status"],
-  overrides?: {
-    error?: OpenResponsesResponse["error"];
-    incompleteDetails?: OpenResponsesResponse["incomplete_details"];
+const asContentPart = (part: ContentPartEventPart): ContentPartEventPart =>
+  part;
+
+const isOutputTextContentPart = (
+  part: unknown
+): part is OutputTextContentPart => {
+  return (
+    typeof part === "object" &&
+    part !== null &&
+    "type" in part &&
+    part.type === "output_text" &&
+    "text" in part &&
+    typeof part.text === "string" &&
+    "annotations" in part &&
+    Array.isArray(part.annotations) &&
+    "logprobs" in part &&
+    Array.isArray(part.logprobs)
+  );
+};
+
+const isRefusalContentPart = (part: unknown): part is RefusalContentPart => {
+  return (
+    typeof part === "object" &&
+    part !== null &&
+    "type" in part &&
+    part.type === "refusal" &&
+    "refusal" in part &&
+    typeof part.refusal === "string"
+  );
+};
+
+const getOutputTextStartedPartOrThrow = (
+  itemId: string,
+  part: unknown
+): OutputTextContentPart => {
+  if (!isOutputTextContentPart(part)) {
+    throw new Error(
+      `Invariant violation: expected output_text for canonical item "${itemId}"`
+    );
   }
-): OpenResponsesEvent => {
-  return {
-    type,
+
+  return part;
+};
+
+const getRefusalStartedPartOrThrow = (
+  itemId: string,
+  part: unknown
+): RefusalContentPart => {
+  if (!isRefusalContentPart(part)) {
+    throw new Error(
+      `Invariant violation: expected refusal for canonical item "${itemId}"`
+    );
+  }
+
+  return part;
+};
+
+const createStartedEvents = (
+  context: SerializerContext,
+  itemId: string,
+  item: Extract<
+    OpenResponsesEvent,
+    { type: "response.output_item.added" }
+  >["item"],
+  part: ContentPartEventPart
+): OpenResponsesEvent[] => {
+  const outputIndex = nextOutputIndex(context, itemId);
+  const events: OpenResponsesEvent[] = [];
+  const inProgressEvent = ensureInProgressEvent(context);
+  if (inProgressEvent) {
+    events.push(inProgressEvent);
+  }
+
+  events.push(
+    {
+      type: "response.output_item.added",
+      sequence_number: context.sequence.next(),
+      output_index: outputIndex,
+      item,
+    },
+    {
+      type: "response.content_part.added",
+      sequence_number: context.sequence.next(),
+      item_id: itemId,
+      output_index: outputIndex,
+      content_index: 0,
+      part,
+    }
+  );
+
+  return events;
+};
+
+const serializeMessageStarted = (
+  event: Extract<InternalSemanticEvent, { type: "message.started" }>,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  const item = context.accumulator.startTextMessageItem({ id: event.itemId });
+  const part = getOutputTextStartedPartOrThrow(event.itemId, item.content[0]);
+  return createStartedEvents(context, event.itemId, item, asContentPart(part));
+};
+
+const serializeTextDelta = (
+  event: Extract<InternalSemanticEvent, { type: "text.delta" }>,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+  context.accumulator.appendOutputTextDelta(event.itemId, event.delta);
+  return [
+    {
+      type: "response.output_text.delta",
+      sequence_number: context.sequence.next(),
+      item_id: event.itemId,
+      output_index: outputIndex,
+      content_index: 0,
+      delta: event.delta,
+      logprobs: [],
+    },
+  ];
+};
+
+const serializeTextCompleted = (
+  event: Extract<InternalSemanticEvent, { type: "text.completed" }>,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+  const finalizedItem = context.accumulator.finalizeMessageItem(
+    event.itemId,
+    "completed"
+  );
+  const finalizedPart = finalizedItem.content[0];
+
+  if (!finalizedPart || finalizedPart.type !== "output_text") {
+    throw new Error(
+      `Invariant violation: expected output_text for canonical item "${event.itemId}"`
+    );
+  }
+
+  return [
+    {
+      type: "response.output_text.done",
+      sequence_number: context.sequence.next(),
+      item_id: event.itemId,
+      output_index: outputIndex,
+      content_index: 0,
+      text: finalizedPart.text,
+      logprobs: [],
+    },
+    {
+      type: "response.content_part.done",
+      sequence_number: context.sequence.next(),
+      item_id: event.itemId,
+      output_index: outputIndex,
+      content_index: 0,
+      part: finalizedPart,
+    },
+    {
+      type: "response.output_item.done",
+      sequence_number: context.sequence.next(),
+      output_index: outputIndex,
+      item: finalizedItem,
+    },
+  ];
+};
+
+const serializeRefusalStarted = (
+  event: Extract<InternalSemanticEvent, { type: "refusal.started" }>,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  const item = context.accumulator.startRefusalMessageItem({
+    id: event.itemId,
+  });
+  const part = getRefusalStartedPartOrThrow(event.itemId, item.content[0]);
+  return createStartedEvents(context, event.itemId, item, asContentPart(part));
+};
+
+const serializeRefusalDelta = (
+  event: Extract<InternalSemanticEvent, { type: "refusal.delta" }>,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+  context.accumulator.appendRefusalDelta(event.itemId, event.delta);
+  return [
+    {
+      type: "response.refusal.delta",
+      sequence_number: context.sequence.next(),
+      item_id: event.itemId,
+      output_index: outputIndex,
+      content_index: 0,
+      delta: event.delta,
+    },
+  ];
+};
+
+const serializeRefusalCompleted = (
+  event: Extract<InternalSemanticEvent, { type: "refusal.completed" }>,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+  const finalizedItem = context.accumulator.finalizeMessageItem(
+    event.itemId,
+    "completed"
+  );
+  const finalizedPart = finalizedItem.content[0];
+
+  if (!finalizedPart || finalizedPart.type !== "refusal") {
+    throw new Error(
+      `Invariant violation: expected refusal for canonical item "${event.itemId}"`
+    );
+  }
+
+  return [
+    {
+      type: "response.refusal.done",
+      sequence_number: context.sequence.next(),
+      item_id: event.itemId,
+      output_index: outputIndex,
+      content_index: 0,
+      refusal: finalizedPart.refusal,
+    },
+    {
+      type: "response.content_part.done",
+      sequence_number: context.sequence.next(),
+      item_id: event.itemId,
+      output_index: outputIndex,
+      content_index: 0,
+      part: finalizedPart,
+    },
+    {
+      type: "response.output_item.done",
+      sequence_number: context.sequence.next(),
+      output_index: outputIndex,
+      item: finalizedItem,
+    },
+  ];
+};
+
+const serializeReasoningStarted = (
+  event: Extract<InternalSemanticEvent, { type: "reasoning.started" }>,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  const item = context.accumulator.startReasoningItem({ id: event.itemId });
+  return createStartedEvents(context, event.itemId, item, {
+    type: "reasoning_text",
+    text: "",
+  });
+};
+
+const serializeReasoningDelta = (
+  event: Extract<InternalSemanticEvent, { type: "reasoning.delta" }>,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+  context.accumulator.appendReasoningDelta(event.itemId, event.delta);
+  return [
+    {
+      type: "response.reasoning.delta",
+      sequence_number: context.sequence.next(),
+      item_id: event.itemId,
+      output_index: outputIndex,
+      content_index: 0,
+      delta: event.delta,
+    },
+  ];
+};
+
+const serializeReasoningCompleted = (
+  event: Extract<InternalSemanticEvent, { type: "reasoning.completed" }>,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+  for (const summaryText of event.summaryTexts ?? []) {
+    context.accumulator.appendReasoningSummary(event.itemId, summaryText);
+  }
+  const finalizedItem = context.accumulator.finalizeReasoningItem(event.itemId);
+  const reasoningText = finalizedItem.content?.[0];
+
+  if (!reasoningText || reasoningText.type !== "reasoning_text") {
+    throw new Error(
+      `Invariant violation: expected reasoning_text for canonical item "${event.itemId}"`
+    );
+  }
+
+  return [
+    {
+      type: "response.reasoning.done",
+      sequence_number: context.sequence.next(),
+      item_id: event.itemId,
+      output_index: outputIndex,
+      content_index: 0,
+      text: reasoningText.text,
+    },
+    {
+      type: "response.content_part.done",
+      sequence_number: context.sequence.next(),
+      item_id: event.itemId,
+      output_index: outputIndex,
+      content_index: 0,
+      part: reasoningText,
+    },
+    {
+      type: "response.output_item.done",
+      sequence_number: context.sequence.next(),
+      output_index: outputIndex,
+      item: finalizedItem,
+    },
+  ];
+};
+
+const serializeAnnotationAdded = (
+  event: Extract<
+    InternalSemanticEvent,
+    { type: "output_text.annotation.added" }
+  >,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+  context.accumulator.addOutputTextAnnotation(event.itemId, event.annotation);
+  const item = context.accumulator.snapshot().find((candidate) => {
+    return candidate.type === "message" && candidate.id === event.itemId;
+  });
+  const textPart = item?.type === "message" ? item.content[0] : undefined;
+  const annotationIndex =
+    textPart?.type === "output_text" ? textPart.annotations.length - 1 : 0;
+
+  return [
+    {
+      type: "response.output_text.annotation.added",
+      sequence_number: context.sequence.next(),
+      item_id: event.itemId,
+      output_index: outputIndex,
+      content_index: 0,
+      annotation_index: Math.max(annotationIndex, 0),
+      annotation: event.annotation,
+    },
+  ];
+};
+
+const serializeFunctionCallStarted = (
+  event: Extract<InternalSemanticEvent, { type: "function_call.started" }>,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  const events: OpenResponsesEvent[] = [];
+  const inProgressEvent = ensureInProgressEvent(context);
+  if (inProgressEvent) {
+    events.push(inProgressEvent);
+  }
+
+  const item = context.accumulator.startFunctionCallItem({
+    id: event.itemId,
+    name: event.name,
+    callId: event.callId,
+    ...(event.arguments !== undefined ? { arguments: event.arguments } : {}),
+  });
+  const outputIndex = nextOutputIndex(context, event.itemId);
+  events.push({
+    type: "response.output_item.added",
     sequence_number: context.sequence.next(),
-    response: buildResponseSnapshot(context, status, overrides),
-  } as OpenResponsesEvent;
+    output_index: outputIndex,
+    item,
+  });
+
+  return events;
+};
+
+const serializeFunctionCallArgumentsDelta = (
+  event: Extract<
+    InternalSemanticEvent,
+    { type: "function_call_arguments.delta" }
+  >,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+  context.accumulator.appendFunctionCallArgumentsDelta(
+    event.itemId,
+    event.delta
+  );
+  return [
+    {
+      type: "response.function_call_arguments.delta",
+      sequence_number: context.sequence.next(),
+      item_id: event.itemId,
+      output_index: outputIndex,
+      delta: event.delta,
+    },
+  ];
+};
+
+const serializeFunctionCallCompleted = (
+  event: Extract<InternalSemanticEvent, { type: "function_call.completed" }>,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+  const finalizedItem = context.accumulator.finalizeFunctionCallItem(
+    event.itemId,
+    "completed"
+  );
+  return [
+    {
+      type: "response.function_call_arguments.done",
+      sequence_number: context.sequence.next(),
+      item_id: event.itemId,
+      output_index: outputIndex,
+      arguments: finalizedItem.arguments,
+    },
+    {
+      type: "response.output_item.done",
+      sequence_number: context.sequence.next(),
+      output_index: outputIndex,
+      item: finalizedItem,
+    },
+  ];
+};
+
+const serializeFunctionCallOutputCompleted = (
+  event: Extract<
+    InternalSemanticEvent,
+    { type: "function_call_output.completed" }
+  >,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  const item = context.accumulator.addFunctionCallOutputItem({
+    id: event.itemId,
+    callId: event.callId,
+    output: event.output,
+  });
+  const outputIndex = nextOutputIndex(context, event.itemId);
+  return [
+    {
+      type: "response.output_item.added",
+      sequence_number: context.sequence.next(),
+      output_index: outputIndex,
+      item,
+    },
+    {
+      type: "response.output_item.done",
+      sequence_number: context.sequence.next(),
+      output_index: outputIndex,
+      item,
+    },
+  ];
+};
+
+const serializeRunCompleted = (
+  event: Extract<InternalSemanticEvent, { type: "run.completed" }>,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  if (event.runId !== context.responseId) {
+    return [];
+  }
+
+  if (context.lifecycle.getStatus() === "queued") {
+    context.lifecycle.start();
+  }
+  context.lifecycle.complete();
+  return [emitLifecycleEvent("response.completed", context, "completed")];
+};
+
+const serializeRunFailed = (
+  event: Extract<InternalSemanticEvent, { type: "run.failed" }>,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  if (event.runId !== context.responseId) {
+    return [];
+  }
+
+  const errorObject = errorToErrorObject(event.error);
+  context.accumulator.finalizeOpenItemsAsIncomplete();
+  if (context.lifecycle.getStatus() === "queued") {
+    context.lifecycle.start();
+  }
+  context.lifecycle.fail(errorObject);
+  return [
+    emitLifecycleEvent("response.failed", context, "failed", {
+      error: errorObject,
+    }),
+  ];
+};
+
+const serializeRunIncomplete = (
+  event: Extract<InternalSemanticEvent, { type: "run.incomplete" }>,
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  if (event.runId !== context.responseId) {
+    return [];
+  }
+
+  context.accumulator.finalizeOpenItemsAsIncomplete();
+  if (context.lifecycle.getStatus() === "queued") {
+    context.lifecycle.start();
+  }
+  context.lifecycle.incomplete();
+  return [
+    emitLifecycleEvent("response.incomplete", context, "incomplete", {
+      incompleteDetails: {
+        reason: event.reason ?? "stream_ended_before_terminal_state",
+      },
+    }),
+  ];
 };
 
 export const serializeInternalEvent = (
@@ -186,472 +699,45 @@ export const serializeInternalEvent = (
       const inProgressEvent = ensureInProgressEvent(context);
       return inProgressEvent ? [inProgressEvent] : [];
     }
-
-    case "message.started": {
-      const item = context.accumulator.startTextMessageItem({
-        id: event.itemId,
-      });
-      const outputIndex = nextOutputIndex(context, event.itemId);
-      const events: OpenResponsesEvent[] = [];
-      const inProgressEvent = ensureInProgressEvent(context);
-      if (inProgressEvent) {
-        events.push(inProgressEvent);
-      }
-
-      events.push(
-        {
-          type: "response.output_item.added",
-          sequence_number: context.sequence.next(),
-          output_index: outputIndex,
-          item,
-        },
-        {
-          type: "response.content_part.added",
-          sequence_number: context.sequence.next(),
-          item_id: event.itemId,
-          output_index: outputIndex,
-          content_index: 0,
-          part: item.content[0] as OpenResponsesEvent extends never
-            ? never
-            : any,
-        }
-      );
-
-      return events;
-    }
-
-    case "text.delta": {
-      const outputIndex = getOutputIndexOrThrow(
-        context,
-        event.itemId,
-        event.type
-      );
-      context.accumulator.appendOutputTextDelta(event.itemId, event.delta);
-      return [
-        {
-          type: "response.output_text.delta",
-          sequence_number: context.sequence.next(),
-          item_id: event.itemId,
-          output_index: outputIndex,
-          content_index: 0,
-          delta: event.delta,
-          logprobs: [],
-        },
-      ];
-    }
-
-    case "text.completed": {
-      const outputIndex = getOutputIndexOrThrow(
-        context,
-        event.itemId,
-        event.type
-      );
-      const finalizedItem = context.accumulator.finalizeMessageItem(
-        event.itemId,
-        "completed"
-      );
-      const finalizedPart = finalizedItem.content[0];
-
-      if (!finalizedPart || finalizedPart.type !== "output_text") {
-        throw new Error(
-          `Invariant violation: expected output_text for canonical item "${event.itemId}"`
-        );
-      }
-
-      return [
-        {
-          type: "response.output_text.done",
-          sequence_number: context.sequence.next(),
-          item_id: event.itemId,
-          output_index: outputIndex,
-          content_index: 0,
-          text: finalizedPart.text,
-          logprobs: [],
-        },
-        {
-          type: "response.content_part.done",
-          sequence_number: context.sequence.next(),
-          item_id: event.itemId,
-          output_index: outputIndex,
-          content_index: 0,
-          part: finalizedPart,
-        },
-        {
-          type: "response.output_item.done",
-          sequence_number: context.sequence.next(),
-          output_index: outputIndex,
-          item: finalizedItem,
-        },
-      ];
-    }
-
-    case "refusal.started": {
-      const item = context.accumulator.startRefusalMessageItem({
-        id: event.itemId,
-      });
-      const outputIndex = nextOutputIndex(context, event.itemId);
-      const events: OpenResponsesEvent[] = [];
-      const inProgressEvent = ensureInProgressEvent(context);
-      if (inProgressEvent) {
-        events.push(inProgressEvent);
-      }
-
-      events.push(
-        {
-          type: "response.output_item.added",
-          sequence_number: context.sequence.next(),
-          output_index: outputIndex,
-          item,
-        },
-        {
-          type: "response.content_part.added",
-          sequence_number: context.sequence.next(),
-          item_id: event.itemId,
-          output_index: outputIndex,
-          content_index: 0,
-          part: item.content[0] as OpenResponsesEvent extends never
-            ? never
-            : any,
-        }
-      );
-
-      return events;
-    }
-
-    case "refusal.delta": {
-      const outputIndex = getOutputIndexOrThrow(
-        context,
-        event.itemId,
-        event.type
-      );
-      context.accumulator.appendRefusalDelta(event.itemId, event.delta);
-      return [
-        {
-          type: "response.refusal.delta",
-          sequence_number: context.sequence.next(),
-          item_id: event.itemId,
-          output_index: outputIndex,
-          content_index: 0,
-          delta: event.delta,
-        },
-      ];
-    }
-
-    case "refusal.completed": {
-      const outputIndex = getOutputIndexOrThrow(
-        context,
-        event.itemId,
-        event.type
-      );
-      const finalizedItem = context.accumulator.finalizeMessageItem(
-        event.itemId,
-        "completed"
-      );
-      const finalizedPart = finalizedItem.content[0];
-
-      if (!finalizedPart || finalizedPart.type !== "refusal") {
-        throw new Error(
-          `Invariant violation: expected refusal for canonical item "${event.itemId}"`
-        );
-      }
-
-      return [
-        {
-          type: "response.refusal.done",
-          sequence_number: context.sequence.next(),
-          item_id: event.itemId,
-          output_index: outputIndex,
-          content_index: 0,
-          refusal: finalizedPart.refusal,
-        },
-        {
-          type: "response.content_part.done",
-          sequence_number: context.sequence.next(),
-          item_id: event.itemId,
-          output_index: outputIndex,
-          content_index: 0,
-          part: finalizedPart,
-        },
-        {
-          type: "response.output_item.done",
-          sequence_number: context.sequence.next(),
-          output_index: outputIndex,
-          item: finalizedItem,
-        },
-      ];
-    }
-
-    case "reasoning.started": {
-      const item = context.accumulator.startReasoningItem({ id: event.itemId });
-      const outputIndex = nextOutputIndex(context, event.itemId);
-      const events: OpenResponsesEvent[] = [];
-      const inProgressEvent = ensureInProgressEvent(context);
-      if (inProgressEvent) {
-        events.push(inProgressEvent);
-      }
-
-      events.push(
-        {
-          type: "response.output_item.added",
-          sequence_number: context.sequence.next(),
-          output_index: outputIndex,
-          item,
-        },
-        {
-          type: "response.content_part.added",
-          sequence_number: context.sequence.next(),
-          item_id: event.itemId,
-          output_index: outputIndex,
-          content_index: 0,
-          part: { type: "reasoning_text", text: "" },
-        }
-      );
-
-      return events;
-    }
-
-    case "reasoning.delta": {
-      const outputIndex = getOutputIndexOrThrow(
-        context,
-        event.itemId,
-        event.type
-      );
-      context.accumulator.appendReasoningDelta(event.itemId, event.delta);
-      return [
-        {
-          type: "response.reasoning.delta",
-          sequence_number: context.sequence.next(),
-          item_id: event.itemId,
-          output_index: outputIndex,
-          content_index: 0,
-          delta: event.delta,
-        },
-      ];
-    }
-
-    case "reasoning.completed": {
-      const outputIndex = getOutputIndexOrThrow(
-        context,
-        event.itemId,
-        event.type
-      );
-      for (const summaryText of event.summaryTexts ?? []) {
-        context.accumulator.appendReasoningSummary(event.itemId, summaryText);
-      }
-      const finalizedItem = context.accumulator.finalizeReasoningItem(
-        event.itemId
-      );
-      const reasoningText = finalizedItem.content?.[0];
-      if (!reasoningText || reasoningText.type !== "reasoning_text") {
-        throw new Error(
-          `Invariant violation: expected reasoning_text for canonical item "${event.itemId}"`
-        );
-      }
-
-      return [
-        {
-          type: "response.reasoning.done",
-          sequence_number: context.sequence.next(),
-          item_id: event.itemId,
-          output_index: outputIndex,
-          content_index: 0,
-          text: reasoningText.text,
-        },
-        {
-          type: "response.content_part.done",
-          sequence_number: context.sequence.next(),
-          item_id: event.itemId,
-          output_index: outputIndex,
-          content_index: 0,
-          part: reasoningText,
-        },
-        {
-          type: "response.output_item.done",
-          sequence_number: context.sequence.next(),
-          output_index: outputIndex,
-          item: finalizedItem,
-        },
-      ];
-    }
-
-    case "output_text.annotation.added": {
-      const outputIndex = getOutputIndexOrThrow(
-        context,
-        event.itemId,
-        event.type
-      );
-      context.accumulator.addOutputTextAnnotation(
-        event.itemId,
-        event.annotation
-      );
-      const item = context.accumulator.snapshot().find((candidate) => {
-        return candidate.type === "message" && candidate.id === event.itemId;
-      });
-      const textPart = item?.type === "message" ? item.content[0] : undefined;
-      const annotationIndex =
-        textPart?.type === "output_text" ? textPart.annotations.length - 1 : 0;
-
-      return [
-        {
-          type: "response.output_text.annotation.added",
-          sequence_number: context.sequence.next(),
-          item_id: event.itemId,
-          output_index: outputIndex,
-          content_index: 0,
-          annotation_index: Math.max(annotationIndex, 0),
-          annotation: event.annotation,
-        },
-      ];
-    }
-
-    case "function_call.started": {
-      const events: OpenResponsesEvent[] = [];
-      const inProgressEvent = ensureInProgressEvent(context);
-      if (inProgressEvent) {
-        events.push(inProgressEvent);
-      }
-      const item = context.accumulator.startFunctionCallItem({
-        id: event.itemId,
-        name: event.name,
-        callId: event.callId,
-        ...(event.arguments !== undefined
-          ? { arguments: event.arguments }
-          : {}),
-      });
-      const outputIndex = nextOutputIndex(context, event.itemId);
-      events.push({
-        type: "response.output_item.added",
-        sequence_number: context.sequence.next(),
-        output_index: outputIndex,
-        item,
-      });
-
-      return events;
-    }
-
-    case "function_call_arguments.delta": {
-      const outputIndex = getOutputIndexOrThrow(
-        context,
-        event.itemId,
-        event.type
-      );
-      context.accumulator.appendFunctionCallArgumentsDelta(
-        event.itemId,
-        event.delta
-      );
-      return [
-        {
-          type: "response.function_call_arguments.delta",
-          sequence_number: context.sequence.next(),
-          item_id: event.itemId,
-          output_index: outputIndex,
-          delta: event.delta,
-        },
-      ];
-    }
-
-    case "function_call.completed": {
-      const outputIndex = getOutputIndexOrThrow(
-        context,
-        event.itemId,
-        event.type
-      );
-      const finalizedItem = context.accumulator.finalizeFunctionCallItem(
-        event.itemId,
-        "completed"
-      );
-      return [
-        {
-          type: "response.function_call_arguments.done",
-          sequence_number: context.sequence.next(),
-          item_id: event.itemId,
-          output_index: outputIndex,
-          arguments: finalizedItem.arguments,
-        },
-        {
-          type: "response.output_item.done",
-          sequence_number: context.sequence.next(),
-          output_index: outputIndex,
-          item: finalizedItem,
-        },
-      ];
-    }
-
-    case "function_call_output.completed": {
-      const item = context.accumulator.addFunctionCallOutputItem({
-        id: event.itemId,
-        callId: event.callId,
-        output: event.output,
-      });
-      const outputIndex = nextOutputIndex(context, event.itemId);
-      return [
-        {
-          type: "response.output_item.added",
-          sequence_number: context.sequence.next(),
-          output_index: outputIndex,
-          item,
-        },
-        {
-          type: "response.output_item.done",
-          sequence_number: context.sequence.next(),
-          output_index: outputIndex,
-          item,
-        },
-      ];
-    }
-
-    case "run.completed": {
-      if (event.runId !== context.responseId) {
-        return [];
-      }
-
-      if (context.lifecycle.getStatus() === "queued") {
-        context.lifecycle.start();
-      }
-      context.lifecycle.complete();
-      return [emitLifecycleEvent("response.completed", context, "completed")];
-    }
-
-    case "run.failed": {
-      if (event.runId !== context.responseId) {
-        return [];
-      }
-
-      const errorObject = errorToErrorObject(event.error);
-      context.accumulator.finalizeOpenItemsAsIncomplete();
-      if (context.lifecycle.getStatus() === "queued") {
-        context.lifecycle.start();
-      }
-      context.lifecycle.fail(errorObject);
-      return [
-        emitLifecycleEvent("response.failed", context, "failed", {
-          error: errorObject,
-        }),
-      ];
-    }
-
-    case "run.incomplete": {
-      if (event.runId !== context.responseId) {
-        return [];
-      }
-
-      context.accumulator.finalizeOpenItemsAsIncomplete();
-      if (context.lifecycle.getStatus() === "queued") {
-        context.lifecycle.start();
-      }
-      context.lifecycle.incomplete();
-      return [
-        emitLifecycleEvent("response.incomplete", context, "incomplete", {
-          incompleteDetails: {
-            reason: event.reason ?? "stream_ended_before_terminal_state",
-          },
-        }),
-      ];
-    }
-
+    case "message.started":
+      return serializeMessageStarted(event, context);
+    case "text.delta":
+      return serializeTextDelta(event, context);
+    case "text.completed":
+      return serializeTextCompleted(event, context);
+    case "refusal.started":
+      return serializeRefusalStarted(event, context);
+    case "refusal.delta":
+      return serializeRefusalDelta(event, context);
+    case "refusal.completed":
+      return serializeRefusalCompleted(event, context);
+    case "reasoning.started":
+      return serializeReasoningStarted(event, context);
+    case "reasoning.delta":
+      return serializeReasoningDelta(event, context);
+    case "reasoning.completed":
+      return serializeReasoningCompleted(event, context);
+    case "output_text.annotation.added":
+      return serializeAnnotationAdded(event, context);
+    case "function_call.started":
+      return serializeFunctionCallStarted(event, context);
+    case "function_call_arguments.delta":
+      return serializeFunctionCallArgumentsDelta(event, context);
+    case "function_call.completed":
+      return serializeFunctionCallCompleted(event, context);
+    case "function_call_output.completed":
+      return serializeFunctionCallOutputCompleted(event, context);
+    case "run.completed":
+      return serializeRunCompleted(event, context);
+    case "run.failed":
+      return serializeRunFailed(event, context);
+    case "run.incomplete":
+      return serializeRunIncomplete(event, context);
     case "tool.started":
     case "tool.completed":
     case "tool.error":
+      return [];
+    default:
       return [];
   }
 };

--- a/packages/openresponses-adapter/src/server/event-serializer.ts
+++ b/packages/openresponses-adapter/src/server/event-serializer.ts
@@ -1,10 +1,3 @@
-/**
- * Event Serializer + SSE Framing
- *
- * Converts internal semantic events into public Open Responses events
- * with response-scoped sequence numbers, and formats SSE frames.
- */
-
 import {
   agentExecutionFailed,
   type InternalError,
@@ -12,13 +5,19 @@ import {
   isInternalError,
 } from "@/core/errors.js";
 import type { InternalSemanticEvent } from "@/core/events.js";
-import {
-  type OpenResponsesEvent,
-  OpenResponsesEventSchema,
-} from "@/core/internal-schemas.js";
-import type { SequenceGenerator, SSEFrame } from "@/core/types.js";
+import type {
+  OpenResponsesEvent,
+  OpenResponsesResponse,
+} from "@/core/schemas.js";
+import { OpenResponsesEventSchema } from "@/core/schemas.js";
+import type {
+  OpenResponsesRequestSnapshot,
+  SequenceGenerator,
+  SSEFrame,
+} from "@/core/types.js";
 import type { AsyncEventQueue } from "@/state/async-event-queue.js";
 import type { CanonicalItemAccumulator } from "@/state/item-accumulator.js";
+import { materializeResponseSnapshot } from "@/state/response-aggregate.js";
 import type { ResponseLifecycle } from "@/state/response-lifecycle.js";
 
 export const createSequenceGenerator = (): SequenceGenerator => {
@@ -41,49 +40,41 @@ export const validateOutgoingEvent = (
 
 export interface SerializerContext {
   accumulator: CanonicalItemAccumulator;
-  sequence: SequenceGenerator;
-  responseId: string;
+  inProgressEmitted?: { value: boolean };
   lifecycle: ResponseLifecycle;
-  inProgressEmitted: { value: boolean };
+  request: OpenResponsesRequestSnapshot;
+  responseId: string;
+  sequence: SequenceGenerator;
   itemOutputIndices: Map<string, number>;
 }
 
-const getOutputIndexOrThrow = (
-  context: SerializerContext,
-  itemId: string,
-  eventType: string
-): number => {
-  const outputIndex = context.itemOutputIndices.get(itemId);
-  if (outputIndex === undefined) {
-    throw new Error(
-      `Invariant violation: received ${eventType} for unknown item ID "${itemId}"`
-    );
-  }
-
-  return outputIndex;
-};
-
-const ensureInProgress = (
-  context: SerializerContext
-): OpenResponsesEvent | null => {
-  if (context.inProgressEmitted.value) {
-    return null;
-  }
-
-  if (context.lifecycle.getStatus() === "queued") {
-    context.lifecycle.start();
-  }
-
-  context.inProgressEmitted.value = true;
-
+const defaultRequestSnapshot = (): OpenResponsesRequestSnapshot => {
   return {
-    type: "response.in_progress",
-    sequence_number: context.sequence.next(),
-    response: {
-      id: context.responseId,
-      object: "response" as const,
-      status: "in_progress" as const,
-    },
+    model: "test-model",
+    input: [],
+    previous_response_id: null,
+    include: [],
+    tools: [],
+    tool_choice: "auto",
+    parallel_tool_calls: true,
+    instructions: null,
+    store: false,
+    background: false,
+    truncation: "disabled",
+    text: { format: { type: "text" }, verbosity: "medium" },
+    reasoning: null,
+    top_p: 1,
+    presence_penalty: 0,
+    frequency_penalty: 0,
+    top_logprobs: 0,
+    temperature: 1,
+    max_output_tokens: null,
+    max_tool_calls: null,
+    service_tier: "default",
+    safety_identifier: null,
+    prompt_cache_key: null,
+    metadata: {},
+    stream_options: null,
   };
 };
 
@@ -100,57 +91,131 @@ const errorToErrorObject = (error: unknown) => {
   return internalErrorToPublicError(internal);
 };
 
+const buildResponseSnapshot = (
+  context: SerializerContext,
+  status?: OpenResponsesResponse["status"],
+  overrides?: {
+    error?: OpenResponsesResponse["error"];
+    incompleteDetails?: OpenResponsesResponse["incomplete_details"];
+  }
+) => {
+  return materializeResponseSnapshot({
+    request: context.request,
+    responseId: context.responseId,
+    createdAt: context.lifecycle.createdAt,
+    completedAt: context.lifecycle.getCompletedAt(),
+    status: status ?? context.lifecycle.getStatus(),
+    output: context.accumulator.snapshot(),
+    error:
+      (overrides?.error as OpenResponsesResponse["error"]) ??
+      context.lifecycle.getError(),
+    incompleteDetails: overrides?.incompleteDetails,
+  });
+};
+
+const getOutputIndexOrThrow = (
+  context: SerializerContext,
+  itemId: string,
+  eventType: string
+): number => {
+  const outputIndex = context.itemOutputIndices.get(itemId);
+  if (outputIndex === undefined) {
+    throw new Error(
+      `Invariant violation: received ${eventType} for unknown item ID "${itemId}"`
+    );
+  }
+
+  return outputIndex;
+};
+
+const nextOutputIndex = (context: SerializerContext, itemId: string): number => {
+  const outputIndex = context.itemOutputIndices.size;
+  context.itemOutputIndices.set(itemId, outputIndex);
+  return outputIndex;
+};
+
+const ensureInProgressEvent = (
+  context: SerializerContext
+): OpenResponsesEvent | null => {
+  if (context.inProgressEmitted?.value) {
+    return null;
+  }
+
+  if (context.lifecycle.getStatus() === "queued") {
+    context.lifecycle.start();
+  }
+
+  if (context.inProgressEmitted) {
+    context.inProgressEmitted.value = true;
+  }
+
+  return emitLifecycleEvent("response.in_progress", context, "in_progress");
+};
+
+const emitLifecycleEvent = (
+  type:
+    | "response.created"
+    | "response.queued"
+    | "response.in_progress"
+    | "response.completed"
+    | "response.failed"
+    | "response.incomplete",
+  context: SerializerContext,
+  status: OpenResponsesResponse["status"],
+  overrides?: {
+    error?: OpenResponsesResponse["error"];
+    incompleteDetails?: OpenResponsesResponse["incomplete_details"];
+  }
+): OpenResponsesEvent => {
+  return {
+    type,
+    sequence_number: context.sequence.next(),
+    response: buildResponseSnapshot(context, status, overrides),
+  } as OpenResponsesEvent;
+};
+
 export const serializeInternalEvent = (
   event: InternalSemanticEvent,
   context: SerializerContext
 ): OpenResponsesEvent[] => {
   switch (event.type) {
     case "run.started": {
-      const inProgressEvent = ensureInProgress(context);
+      const inProgressEvent = ensureInProgressEvent(context);
       return inProgressEvent ? [inProgressEvent] : [];
     }
 
     case "message.started": {
+      const item = context.accumulator.startTextMessageItem({ id: event.itemId });
+      const outputIndex = nextOutputIndex(context, event.itemId);
       const events: OpenResponsesEvent[] = [];
-
-      const inProgressEvent = ensureInProgress(context);
+      const inProgressEvent = ensureInProgressEvent(context);
       if (inProgressEvent) {
         events.push(inProgressEvent);
       }
 
-      const item = context.accumulator.startMessageItem({ id: event.itemId });
-      const outputIndex = context.itemOutputIndices.size;
-      context.itemOutputIndices.set(event.itemId, outputIndex);
-
-      const part = context.accumulator.startOutputTextPart(event.itemId);
-
-      events.push({
-        type: "response.output_item.added",
-        sequence_number: context.sequence.next(),
-        output_index: outputIndex,
-        item,
-      });
-
-      events.push({
-        type: "response.content_part.added",
-        sequence_number: context.sequence.next(),
-        item_id: event.itemId,
-        output_index: outputIndex,
-        content_index: 0,
-        part,
-      });
+      events.push(
+        {
+          type: "response.output_item.added",
+          sequence_number: context.sequence.next(),
+          output_index: outputIndex,
+          item,
+        },
+        {
+          type: "response.content_part.added",
+          sequence_number: context.sequence.next(),
+          item_id: event.itemId,
+          output_index: outputIndex,
+          content_index: 0,
+          part: item.content[0] as OpenResponsesEvent extends never ? never : any,
+        }
+      );
 
       return events;
     }
 
     case "text.delta": {
-      const outputIndex = getOutputIndexOrThrow(
-        context,
-        event.itemId,
-        "text.delta"
-      );
-      context.accumulator.appendOutputTextDelta(event.itemId, 0, event.delta);
-
+      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+      context.accumulator.appendOutputTextDelta(event.itemId, event.delta);
       return [
         {
           type: "response.output_text.delta",
@@ -159,24 +224,24 @@ export const serializeInternalEvent = (
           output_index: outputIndex,
           content_index: 0,
           delta: event.delta,
+          logprobs: [],
         },
       ];
     }
 
     case "text.completed": {
-      const outputIndex = getOutputIndexOrThrow(
-        context,
-        event.itemId,
-        "text.completed"
-      );
-      const finalizedPart = context.accumulator.finalizeOutputTextPart(
-        event.itemId,
-        0
-      );
-      const finalizedItem = context.accumulator.finalizeItem(
+      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+      const finalizedItem = context.accumulator.finalizeMessageItem(
         event.itemId,
         "completed"
       );
+      const finalizedPart = finalizedItem.content[0];
+
+      if (!finalizedPart || finalizedPart.type !== "output_text") {
+        throw new Error(
+          `Invariant violation: expected output_text for canonical item "${event.itemId}"`
+        );
+      }
 
       return [
         {
@@ -186,6 +251,7 @@ export const serializeInternalEvent = (
           output_index: outputIndex,
           content_index: 0,
           text: finalizedPart.text,
+          logprobs: [],
         },
         {
           type: "response.content_part.done",
@@ -204,49 +270,41 @@ export const serializeInternalEvent = (
       ];
     }
 
-    case "function_call.started": {
+    case "refusal.started": {
+      const item = context.accumulator.startRefusalMessageItem({ id: event.itemId });
+      const outputIndex = nextOutputIndex(context, event.itemId);
       const events: OpenResponsesEvent[] = [];
-
-      const inProgressEvent = ensureInProgress(context);
+      const inProgressEvent = ensureInProgressEvent(context);
       if (inProgressEvent) {
         events.push(inProgressEvent);
       }
 
-      const item = context.accumulator.startFunctionCallItem({
-        id: event.itemId,
-        name: event.name,
-        callId: event.callId,
-        ...(event.arguments !== undefined
-          ? { arguments: event.arguments }
-          : {}),
-      });
-      const outputIndex = context.itemOutputIndices.size;
-      context.itemOutputIndices.set(event.itemId, outputIndex);
-
-      events.push({
-        type: "response.output_item.added",
-        sequence_number: context.sequence.next(),
-        output_index: outputIndex,
-        item,
-      });
+      events.push(
+        {
+          type: "response.output_item.added",
+          sequence_number: context.sequence.next(),
+          output_index: outputIndex,
+          item,
+        },
+        {
+          type: "response.content_part.added",
+          sequence_number: context.sequence.next(),
+          item_id: event.itemId,
+          output_index: outputIndex,
+          content_index: 0,
+          part: item.content[0] as OpenResponsesEvent extends never ? never : any,
+        }
+      );
 
       return events;
     }
 
-    case "function_call_arguments.delta": {
-      const outputIndex = getOutputIndexOrThrow(
-        context,
-        event.itemId,
-        "function_call_arguments.delta"
-      );
-      context.accumulator.appendFunctionCallArgumentsDelta(
-        event.itemId,
-        event.delta
-      );
-
+    case "refusal.delta": {
+      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+      context.accumulator.appendRefusalDelta(event.itemId, event.delta);
       return [
         {
-          type: "response.function_call_arguments.delta",
+          type: "response.refusal.delta",
           sequence_number: context.sequence.next(),
           item_id: event.itemId,
           output_index: outputIndex,
@@ -256,34 +314,233 @@ export const serializeInternalEvent = (
       ];
     }
 
-    case "function_call.completed": {
-      const outputIndex = getOutputIndexOrThrow(
-        context,
-        event.itemId,
-        "function_call.completed"
-      );
-      const finalizedItem = context.accumulator.finalizeItem(
+    case "refusal.completed": {
+      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+      const finalizedItem = context.accumulator.finalizeMessageItem(
         event.itemId,
         "completed"
       );
+      const finalizedPart = finalizedItem.content[0];
 
-      const args =
-        finalizedItem.type === "function_call" ? finalizedItem.arguments : "";
+      if (!finalizedPart || finalizedPart.type !== "refusal") {
+        throw new Error(
+          `Invariant violation: expected refusal for canonical item "${event.itemId}"`
+        );
+      }
 
       return [
         {
-          type: "response.function_call_arguments.done",
+          type: "response.refusal.done",
           sequence_number: context.sequence.next(),
           item_id: event.itemId,
           output_index: outputIndex,
           content_index: 0,
-          arguments: args,
+          refusal: finalizedPart.refusal,
+        },
+        {
+          type: "response.content_part.done",
+          sequence_number: context.sequence.next(),
+          item_id: event.itemId,
+          output_index: outputIndex,
+          content_index: 0,
+          part: finalizedPart,
         },
         {
           type: "response.output_item.done",
           sequence_number: context.sequence.next(),
           output_index: outputIndex,
           item: finalizedItem,
+        },
+      ];
+    }
+
+    case "reasoning.started": {
+      const item = context.accumulator.startReasoningItem({ id: event.itemId });
+      const outputIndex = nextOutputIndex(context, event.itemId);
+      const events: OpenResponsesEvent[] = [];
+      const inProgressEvent = ensureInProgressEvent(context);
+      if (inProgressEvent) {
+        events.push(inProgressEvent);
+      }
+
+      events.push(
+        {
+          type: "response.output_item.added",
+          sequence_number: context.sequence.next(),
+          output_index: outputIndex,
+          item,
+        },
+        {
+          type: "response.content_part.added",
+          sequence_number: context.sequence.next(),
+          item_id: event.itemId,
+          output_index: outputIndex,
+          content_index: 0,
+          part: { type: "reasoning_text", text: "" },
+        }
+      );
+
+      return events;
+    }
+
+    case "reasoning.delta": {
+      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+      context.accumulator.appendReasoningDelta(event.itemId, event.delta);
+      return [
+        {
+          type: "response.reasoning.delta",
+          sequence_number: context.sequence.next(),
+          item_id: event.itemId,
+          output_index: outputIndex,
+          content_index: 0,
+          delta: event.delta,
+        },
+      ];
+    }
+
+    case "reasoning.completed": {
+      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+      for (const summaryText of event.summaryTexts ?? []) {
+        context.accumulator.appendReasoningSummary(event.itemId, summaryText);
+      }
+      const finalizedItem = context.accumulator.finalizeReasoningItem(event.itemId);
+      const reasoningText = finalizedItem.content?.[0];
+      if (!reasoningText || reasoningText.type !== "reasoning_text") {
+        throw new Error(
+          `Invariant violation: expected reasoning_text for canonical item "${event.itemId}"`
+        );
+      }
+
+      return [
+        {
+          type: "response.reasoning.done",
+          sequence_number: context.sequence.next(),
+          item_id: event.itemId,
+          output_index: outputIndex,
+          content_index: 0,
+          text: reasoningText.text,
+        },
+        {
+          type: "response.content_part.done",
+          sequence_number: context.sequence.next(),
+          item_id: event.itemId,
+          output_index: outputIndex,
+          content_index: 0,
+          part: reasoningText,
+        },
+        {
+          type: "response.output_item.done",
+          sequence_number: context.sequence.next(),
+          output_index: outputIndex,
+          item: finalizedItem,
+        },
+      ];
+    }
+
+    case "output_text.annotation.added": {
+      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+      context.accumulator.addOutputTextAnnotation(event.itemId, event.annotation);
+      const item = context.accumulator.snapshot().find((candidate) => {
+        return candidate.type === "message" && candidate.id === event.itemId;
+      });
+      const textPart = item?.type === "message" ? item.content[0] : undefined;
+      const annotationIndex =
+        textPart?.type === "output_text" ? textPart.annotations.length - 1 : 0;
+
+      return [
+        {
+          type: "response.output_text.annotation.added",
+          sequence_number: context.sequence.next(),
+          item_id: event.itemId,
+          output_index: outputIndex,
+          content_index: 0,
+          annotation_index: Math.max(annotationIndex, 0),
+          annotation: event.annotation,
+        },
+      ];
+    }
+
+    case "function_call.started": {
+      const events: OpenResponsesEvent[] = [];
+      const inProgressEvent = ensureInProgressEvent(context);
+      if (inProgressEvent) {
+        events.push(inProgressEvent);
+      }
+      const item = context.accumulator.startFunctionCallItem({
+        id: event.itemId,
+        name: event.name,
+        callId: event.callId,
+        ...(event.arguments !== undefined ? { arguments: event.arguments } : {}),
+      });
+      const outputIndex = nextOutputIndex(context, event.itemId);
+      events.push(
+        {
+          type: "response.output_item.added",
+          sequence_number: context.sequence.next(),
+          output_index: outputIndex,
+          item,
+        }
+      );
+
+      return events;
+    }
+
+    case "function_call_arguments.delta": {
+      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+      context.accumulator.appendFunctionCallArgumentsDelta(event.itemId, event.delta);
+      return [
+        {
+          type: "response.function_call_arguments.delta",
+          sequence_number: context.sequence.next(),
+          item_id: event.itemId,
+          output_index: outputIndex,
+          delta: event.delta,
+        },
+      ];
+    }
+
+    case "function_call.completed": {
+      const outputIndex = getOutputIndexOrThrow(context, event.itemId, event.type);
+      const finalizedItem = context.accumulator.finalizeFunctionCallItem(
+        event.itemId,
+        "completed"
+      );
+      return [
+        {
+          type: "response.function_call_arguments.done",
+          sequence_number: context.sequence.next(),
+          item_id: event.itemId,
+          output_index: outputIndex,
+          arguments: finalizedItem.arguments,
+        },
+        {
+          type: "response.output_item.done",
+          sequence_number: context.sequence.next(),
+          output_index: outputIndex,
+          item: finalizedItem,
+        },
+      ];
+    }
+
+    case "function_call_output.completed": {
+      const item = context.accumulator.addFunctionCallOutputItem({
+        id: event.itemId,
+        callId: event.callId,
+        output: event.output,
+      });
+      const outputIndex = nextOutputIndex(context, event.itemId);
+      return [
+        {
+          type: "response.output_item.added",
+          sequence_number: context.sequence.next(),
+          output_index: outputIndex,
+          item,
+        },
+        {
+          type: "response.output_item.done",
+          sequence_number: context.sequence.next(),
+          output_index: outputIndex,
+          item,
         },
       ];
     }
@@ -297,17 +554,7 @@ export const serializeInternalEvent = (
         context.lifecycle.start();
       }
       context.lifecycle.complete();
-      return [
-        {
-          type: "response.completed",
-          sequence_number: context.sequence.next(),
-          response: {
-            id: context.responseId,
-            object: "response" as const,
-            status: "completed" as const,
-          },
-        },
-      ];
+      return [emitLifecycleEvent("response.completed", context, "completed")];
     }
 
     case "run.failed": {
@@ -316,33 +563,40 @@ export const serializeInternalEvent = (
       }
 
       const errorObject = errorToErrorObject(event.error);
-
+      context.accumulator.finalizeOpenItemsAsIncomplete();
       if (context.lifecycle.getStatus() === "queued") {
         context.lifecycle.start();
       }
       context.lifecycle.fail(errorObject);
-
       return [
-        {
-          type: "response.failed",
-          sequence_number: context.sequence.next(),
-          response: {
-            id: context.responseId,
-            object: "response" as const,
-            status: "failed" as const,
-          },
+        emitLifecycleEvent("response.failed", context, "failed", {
           error: errorObject,
-        },
+        }),
       ];
     }
 
-    // Internal-only events — not published to the wire
+    case "run.incomplete": {
+      if (event.runId !== context.responseId) {
+        return [];
+      }
+
+      context.accumulator.finalizeOpenItemsAsIncomplete();
+      if (context.lifecycle.getStatus() === "queued") {
+        context.lifecycle.start();
+      }
+      context.lifecycle.incomplete();
+      return [
+        emitLifecycleEvent("response.incomplete", context, "incomplete", {
+          incompleteDetails: {
+            reason: event.reason ?? "stream_ended_before_terminal_state",
+          },
+        }),
+      ];
+    }
+
     case "tool.started":
     case "tool.completed":
     case "tool.error":
-      return [];
-
-    default:
       return [];
   }
 };
@@ -351,16 +605,25 @@ export async function* createEventSerializer(params: {
   queue: AsyncEventQueue<InternalSemanticEvent>;
   accumulator: CanonicalItemAccumulator;
   lifecycle: ResponseLifecycle;
+  request?: OpenResponsesRequestSnapshot;
   responseId: string;
 }): AsyncGenerator<OpenResponsesEvent | "[DONE]"> {
   const context: SerializerContext = {
     accumulator: params.accumulator,
-    sequence: createSequenceGenerator(),
-    responseId: params.responseId,
-    lifecycle: params.lifecycle,
     inProgressEmitted: { value: false },
+    lifecycle: params.lifecycle,
+    request: params.request ?? defaultRequestSnapshot(),
+    responseId: params.responseId,
+    sequence: createSequenceGenerator(),
     itemOutputIndices: new Map(),
   };
+
+  yield validateOutgoingEvent(
+    emitLifecycleEvent("response.created", context, "queued")
+  );
+  yield validateOutgoingEvent(
+    emitLifecycleEvent("response.queued", context, "queued")
+  );
 
   try {
     for await (const event of params.queue) {
@@ -370,27 +633,35 @@ export async function* createEventSerializer(params: {
       }
     }
   } catch (error) {
-    // Queue was fail()ed or accumulator threw — emit response.failed if still in_progress
-    const status = params.lifecycle.getStatus();
-    if (status === "in_progress" || status === "queued") {
-      const errorObject = errorToErrorObject(error);
-
-      if (status === "queued") {
-        params.lifecycle.start();
-      }
-      params.lifecycle.fail(errorObject);
-
-      yield validateOutgoingEvent({
-        type: "response.failed",
-        sequence_number: context.sequence.next(),
-        response: {
-          id: params.responseId,
-          object: "response" as const,
-          status: "failed" as const,
-        },
-        error: errorObject,
-      } satisfies OpenResponsesEvent);
+    const errorObject = errorToErrorObject(error);
+    context.accumulator.finalizeOpenItemsAsIncomplete();
+    if (params.lifecycle.getStatus() === "queued") {
+      params.lifecycle.start();
     }
+    if (params.lifecycle.getStatus() === "in_progress") {
+      params.lifecycle.fail(errorObject);
+      yield validateOutgoingEvent(
+        emitLifecycleEvent("response.failed", context, "failed", {
+          error: errorObject,
+        })
+      );
+    }
+  }
+
+  const status = params.lifecycle.getStatus();
+  if (status === "queued" || status === "in_progress") {
+    context.accumulator.finalizeOpenItemsAsIncomplete();
+    if (status === "queued") {
+      params.lifecycle.start();
+    }
+    params.lifecycle.incomplete();
+    yield validateOutgoingEvent(
+      emitLifecycleEvent("response.incomplete", context, "incomplete", {
+        incompleteDetails: {
+          reason: "stream_ended_before_terminal_state",
+        },
+      })
+    );
   }
 
   yield "[DONE]";

--- a/packages/openresponses-adapter/src/server/hono.ts
+++ b/packages/openresponses-adapter/src/server/hono.ts
@@ -13,8 +13,8 @@ import {
   unsupportedMediaType,
 } from "@/core/errors.js";
 import type { OpenResponsesHandlerOptions } from "@/core/index.js";
-import type { OpenResponsesEvent } from "@/core/internal-schemas.js";
 import {
+  type OpenResponsesEvent,
   type OpenResponsesRequest,
   OpenResponsesRequestSchema,
 } from "@/core/schemas.js";
@@ -154,7 +154,7 @@ const streamOpenResponses = <E extends Env = Env>(params: {
         }
 
         if (chunk.type === "response.failed") {
-          terminalErrorCode = chunk.error.code;
+          terminalErrorCode = chunk.response.error?.code ?? "agent_execution_failed";
         }
 
         await stream.writeSSE(formatSSEFrame(chunk));

--- a/packages/openresponses-adapter/src/server/hono.ts
+++ b/packages/openresponses-adapter/src/server/hono.ts
@@ -154,7 +154,8 @@ const streamOpenResponses = <E extends Env = Env>(params: {
         }
 
         if (chunk.type === "response.failed") {
-          terminalErrorCode = chunk.response.error?.code ?? "agent_execution_failed";
+          terminalErrorCode =
+            chunk.response.error?.code ?? "agent_execution_failed";
         }
 
         await stream.writeSSE(formatSSEFrame(chunk));

--- a/packages/openresponses-adapter/src/server/previous-response.ts
+++ b/packages/openresponses-adapter/src/server/previous-response.ts
@@ -880,14 +880,6 @@ const inputItemToMessage = (item: InputItem): LangChainMessageLike => {
     };
   }
 
-  if (item.type !== "function_call_output") {
-    return {
-      type: "ai",
-      role: "assistant",
-      content: [],
-    };
-  }
-
   return {
     type: "tool",
     role: "tool",

--- a/packages/openresponses-adapter/src/server/previous-response.ts
+++ b/packages/openresponses-adapter/src/server/previous-response.ts
@@ -17,12 +17,10 @@ import type {
   OutputItem,
   OutputTextPart,
   ToolChoice,
-} from "@/core/internal-schemas.js";
-import {
-  type OpenResponsesRequest,
-  OpenResponsesRequestSchema,
-  type OpenResponsesResponse,
+  OpenResponsesRequest,
+  OpenResponsesResponse,
 } from "@/core/schemas.js";
+import { OpenResponsesRequestSchema } from "@/core/schemas.js";
 import { getEffectiveToolChoiceMode } from "@/core/tool-policy.js";
 import type {
   LangChainMessageLike,
@@ -357,7 +355,32 @@ const outputItemToInputItem = (item: OutputItem): InputItem => {
     return {
       type: "message",
       role: "assistant",
-      content: safeStructuredClone(item.content),
+      content: safeStructuredClone(
+        item.content.filter((part) => {
+          return part.type === "output_text" || part.type === "refusal";
+        })
+      ),
+    };
+  }
+
+  if (item.type === "reasoning") {
+    return {
+      type: "message",
+      role: "assistant",
+      content: item.summary
+        .map((part) => {
+          return "text" in part ? part.text : "";
+        })
+        .join(" "),
+    };
+  }
+
+  if (item.type === "function_call_output") {
+    return {
+      type: "function_call_output",
+      call_id: item.call_id,
+      output: safeStructuredClone(item.output),
+      status: item.status,
     };
   }
 
@@ -389,6 +412,7 @@ const createOutputTextPart = (text: string): OutputTextPart => {
     type: "output_text",
     text,
     annotations: [],
+    logprobs: [],
   };
 };
 
@@ -583,8 +607,19 @@ const toFunctionCallOutputValue = (
     return value;
   }
 
-  if (Array.isArray(value) && value.every(isRecord)) {
-    return safeStructuredClone(value);
+  if (
+    Array.isArray(value) &&
+    value.every((candidate) => {
+      return (
+        isRecord(candidate) &&
+        typeof candidate.type === "string" &&
+        (candidate.type === "input_text" ||
+          candidate.type === "input_image" ||
+          candidate.type === "input_file")
+      );
+    })
+  ) {
+    return safeStructuredClone(value) as Record<string, unknown>[];
   }
 
   if (value === undefined) {
@@ -605,11 +640,15 @@ const createToolResultInputItems = (
   }
 
   const status = toOptionalInputStatus(value.status);
+  const output = toFunctionCallOutputValue(value.content) as Extract<
+    InputItem,
+    { type: "function_call_output" }
+  >["output"];
   return [
     {
       type: "function_call_output",
       call_id: callId,
-      output: toFunctionCallOutputValue(value.content),
+      output,
       ...(status === undefined ? {} : { status }),
     },
   ];
@@ -841,6 +880,14 @@ const inputItemToMessage = (item: InputItem): LangChainMessageLike => {
     };
   }
 
+  if (item.type !== "function_call_output") {
+    return {
+      type: "ai",
+      role: "assistant",
+      content: [],
+    };
+  }
+
   return {
     type: "tool",
     role: "tool",
@@ -1015,6 +1062,7 @@ const normalizeStoredOutputTextPart = (
       type: "output_text",
       text: value,
       annotations: [],
+      logprobs: [],
     };
   }
 
@@ -1033,6 +1081,7 @@ const normalizeStoredOutputTextPart = (
       type: "output_text",
       text,
       annotations,
+      logprobs: [],
     };
   }
 

--- a/packages/openresponses-adapter/src/server/previous-response.ts
+++ b/packages/openresponses-adapter/src/server/previous-response.ts
@@ -14,11 +14,11 @@ import type {
   ErrorObject,
   FunctionTool,
   InputItem,
+  OpenResponsesRequest,
+  OpenResponsesResponse,
   OutputItem,
   OutputTextPart,
   ToolChoice,
-  OpenResponsesRequest,
-  OpenResponsesResponse,
 } from "@/core/schemas.js";
 import { OpenResponsesRequestSchema } from "@/core/schemas.js";
 import { getEffectiveToolChoiceMode } from "@/core/tool-policy.js";
@@ -878,6 +878,10 @@ const inputItemToMessage = (item: InputItem): LangChainMessageLike => {
         },
       ],
     };
+  }
+
+  if (item.type !== "function_call_output") {
+    throw new Error(`Unsupported input item type '${item.type}'`);
   }
 
   return {

--- a/packages/openresponses-adapter/src/state/index.ts
+++ b/packages/openresponses-adapter/src/state/index.ts
@@ -4,10 +4,15 @@ export {
 } from "./async-event-queue.js";
 export {
   type CanonicalFunctionCallItem,
+  type CanonicalFunctionCallOutputItem,
   type CanonicalItemAccumulator,
   type CanonicalMessageItem,
   type CanonicalOutputItem,
   type CanonicalOutputTextPart,
+  type CanonicalReasoningItem,
+  type CanonicalReasoningTextPart,
+  type CanonicalRefusalPart,
+  type CanonicalSummaryTextPart,
   createCanonicalItemAccumulator,
 } from "./item-accumulator.js";
 export {

--- a/packages/openresponses-adapter/src/state/item-accumulator.ts
+++ b/packages/openresponses-adapter/src/state/item-accumulator.ts
@@ -149,6 +149,10 @@ type MutableItem =
   | MutableFunctionCallOutputItem
   | MutableReasoningItem;
 
+const unreachableItemKind = (value: never): never => {
+  throw new Error(`Unhandled canonical item kind: ${String(value)}`);
+};
+
 const duplicateTerminalError = (target: string): never => {
   throw invalidRequest(`${target} already received a terminal event`);
 };
@@ -239,6 +243,8 @@ const asOutputItem = (item: MutableItem): CanonicalOutputItem => {
       return asFunctionCallOutputItem(item);
     case "reasoning":
       return asReasoningItem(item);
+    default:
+      return unreachableItemKind(item);
   }
 };
 
@@ -374,6 +380,8 @@ class DefaultCanonicalItemAccumulator implements CanonicalItemAccumulator {
         return this.finalizeReasoningItem(itemId, status);
       case "function_call_output":
         return asFunctionCallOutputItem(item);
+      default:
+        return unreachableItemKind(item);
     }
   }
 
@@ -482,12 +490,6 @@ class DefaultCanonicalItemAccumulator implements CanonicalItemAccumulator {
 
   appendReasoningSummary(itemId: string, text: string): void {
     const item = this.#getReasoningItem(itemId);
-    const lastSummary = item.summary.at(-1);
-    if (lastSummary) {
-      lastSummary.text += text;
-      return;
-    }
-
     item.summary.push({ type: "summary_text", text });
   }
 

--- a/packages/openresponses-adapter/src/state/item-accumulator.ts
+++ b/packages/openresponses-adapter/src/state/item-accumulator.ts
@@ -44,7 +44,10 @@ export interface CanonicalItemAccumulator {
     delta?: string
   ): void;
   appendRefusalDelta(itemId: string, delta: string): void;
-  addOutputTextAnnotation(itemId: string, annotation: Record<string, unknown>): void;
+  addOutputTextAnnotation(
+    itemId: string,
+    annotation: Record<string, unknown>
+  ): void;
   finalizeOutputTextPart(
     itemId: string,
     contentIndex?: number
@@ -150,7 +153,9 @@ const duplicateTerminalError = (target: string): never => {
   throw invalidRequest(`${target} already received a terminal event`);
 };
 
-const asOutputTextPart = (part: MutableOutputTextPart): CanonicalOutputTextPart => {
+const asOutputTextPart = (
+  part: MutableOutputTextPart
+): CanonicalOutputTextPart => {
   return {
     type: "output_text",
     text: part.text,
@@ -169,7 +174,9 @@ const asRefusalPart = (part: MutableRefusalPart): CanonicalRefusalPart => {
 };
 
 const asMessagePart = (part: MutableMessagePart): MessagePart => {
-  return part.kind === "output_text" ? asOutputTextPart(part) : asRefusalPart(part);
+  return part.kind === "output_text"
+    ? asOutputTextPart(part)
+    : asRefusalPart(part);
 };
 
 const asMessageItem = (item: MutableMessageItem): CanonicalMessageItem => {
@@ -202,7 +209,9 @@ const asFunctionCallOutputItem = (
     id: item.id,
     type: "function_call_output",
     call_id: item.callId,
-    output: structuredClone(item.output) as CanonicalFunctionCallOutputItem["output"],
+    output: structuredClone(
+      item.output
+    ) as CanonicalFunctionCallOutputItem["output"],
     status: item.status,
   };
 };
@@ -316,7 +325,9 @@ class DefaultCanonicalItemAccumulator implements CanonicalItemAccumulator {
     }
 
     const nextDelta =
-      typeof contentIndexOrDelta === "string" ? contentIndexOrDelta : (delta ?? "");
+      typeof contentIndexOrDelta === "string"
+        ? contentIndexOrDelta
+        : (delta ?? "");
     part.text += nextDelta;
   }
 
@@ -329,7 +340,10 @@ class DefaultCanonicalItemAccumulator implements CanonicalItemAccumulator {
     part.refusal += delta;
   }
 
-  addOutputTextAnnotation(itemId: string, annotation: Record<string, unknown>): void {
+  addOutputTextAnnotation(
+    itemId: string,
+    annotation: Record<string, unknown>
+  ): void {
     const part = this.#getOutputTextPart(itemId);
     part.annotations.push(structuredClone(annotation));
   }
@@ -552,7 +566,9 @@ class DefaultCanonicalItemAccumulator implements CanonicalItemAccumulator {
   #getReasoningItem(itemId: string): MutableReasoningItem {
     const item = this.#getItem(itemId);
     if (item.kind !== "reasoning") {
-      throw invalidRequest(`Canonical item '${itemId}' is not a reasoning item`);
+      throw invalidRequest(
+        `Canonical item '${itemId}' is not a reasoning item`
+      );
     }
 
     return item;

--- a/packages/openresponses-adapter/src/state/item-accumulator.ts
+++ b/packages/openresponses-adapter/src/state/item-accumulator.ts
@@ -1,39 +1,87 @@
 import { invalidRequest } from "@/core/errors.js";
 import type {
   FunctionCallItem,
+  FunctionCallOutputItem,
   MessageOutputItem,
   OutputItem,
   OutputTextPart,
-} from "@/core/internal-schemas.js";
+  ReasoningItem,
+  RefusalContent,
+} from "@/core/schemas.js";
+
+interface ReasoningTextPart {
+  readonly type: "reasoning_text";
+  text: string;
+}
+
+interface SummaryTextPart {
+  readonly type: "summary_text";
+  text: string;
+}
+
+type MessagePart = OutputTextPart | RefusalContent;
+
+type ReasoningContentPart = ReasoningTextPart;
 
 export type CanonicalOutputItem = OutputItem;
 export type CanonicalMessageItem = MessageOutputItem;
 export type CanonicalFunctionCallItem = FunctionCallItem;
+export type CanonicalFunctionCallOutputItem = FunctionCallOutputItem;
+export type CanonicalReasoningItem = ReasoningItem;
 export type CanonicalOutputTextPart = OutputTextPart;
+export type CanonicalRefusalPart = RefusalContent;
+export type CanonicalReasoningTextPart = ReasoningTextPart;
+export type CanonicalSummaryTextPart = SummaryTextPart;
 
 export interface CanonicalItemAccumulator {
   startMessageItem(input?: { id?: string }): CanonicalMessageItem;
+  startTextMessageItem(input?: { id?: string }): CanonicalMessageItem;
+  startRefusalMessageItem(input?: { id?: string }): CanonicalMessageItem;
+  startOutputTextPart(itemId: string): CanonicalOutputTextPart;
+  appendOutputTextDelta(
+    itemId: string,
+    contentIndexOrDelta: number | string,
+    delta?: string
+  ): void;
+  appendRefusalDelta(itemId: string, delta: string): void;
+  addOutputTextAnnotation(itemId: string, annotation: Record<string, unknown>): void;
+  finalizeOutputTextPart(
+    itemId: string,
+    contentIndex?: number
+  ): CanonicalOutputTextPart;
+  finalizeItem(
+    itemId: string,
+    status: "completed" | "incomplete"
+  ): CanonicalOutputItem;
+  finalizeMessageItem(
+    itemId: string,
+    status: "completed" | "incomplete"
+  ): CanonicalMessageItem;
   startFunctionCallItem(input: {
     name: string;
     callId: string;
     id?: string;
     arguments?: string;
   }): CanonicalFunctionCallItem;
-  startOutputTextPart(itemId: string): CanonicalOutputTextPart;
-  appendOutputTextDelta(
-    itemId: string,
-    contentIndex: number,
-    delta: string
-  ): void;
   appendFunctionCallArgumentsDelta(itemId: string, delta: string): void;
-  finalizeOutputTextPart(
-    itemId: string,
-    contentIndex: number
-  ): CanonicalOutputTextPart;
-  finalizeItem(
+  finalizeFunctionCallItem(
     itemId: string,
     status: "completed" | "incomplete"
-  ): CanonicalOutputItem;
+  ): CanonicalFunctionCallItem;
+  addFunctionCallOutputItem(input: {
+    callId: string;
+    output: string | Record<string, unknown>[];
+    id?: string;
+    status?: "completed" | "incomplete";
+  }): CanonicalFunctionCallOutputItem;
+  startReasoningItem(input?: { id?: string }): CanonicalReasoningItem;
+  appendReasoningDelta(itemId: string, delta: string): void;
+  appendReasoningSummary(itemId: string, text: string): void;
+  finalizeReasoningItem(
+    itemId: string,
+    status?: "completed" | "incomplete"
+  ): CanonicalReasoningItem;
+  finalizeOpenItemsAsIncomplete(): CanonicalOutputItem[];
   snapshot(): CanonicalOutputItem[];
 }
 
@@ -41,19 +89,27 @@ export interface CanonicalItemAccumulatorOptions {
   generateId: () => string;
 }
 
-interface MutableTextPart {
-  readonly type: "output_text";
-  status: "in_progress" | "completed";
+interface MutableOutputTextPart {
+  readonly kind: "output_text";
   text: string;
+  annotations: Record<string, unknown>[];
   finalized: boolean;
 }
+
+interface MutableRefusalPart {
+  readonly kind: "refusal";
+  refusal: string;
+  finalized: boolean;
+}
+
+type MutableMessagePart = MutableOutputTextPart | MutableRefusalPart;
 
 interface MutableMessageItem {
   readonly kind: "message";
   readonly id: string;
   status: "in_progress" | "completed" | "incomplete";
   finalized: boolean;
-  content: MutableTextPart[];
+  content: MutableMessagePart[];
 }
 
 interface MutableFunctionCallItem {
@@ -66,18 +122,54 @@ interface MutableFunctionCallItem {
   finalized: boolean;
 }
 
-type MutableItem = MutableMessageItem | MutableFunctionCallItem;
+interface MutableFunctionCallOutputItem {
+  readonly kind: "function_call_output";
+  readonly id: string;
+  readonly callId: string;
+  output: string | Record<string, unknown>[];
+  status: "completed" | "incomplete";
+  finalized: true;
+}
+
+interface MutableReasoningItem {
+  readonly kind: "reasoning";
+  readonly id: string;
+  status: "in_progress" | "completed" | "incomplete";
+  finalized: boolean;
+  content: ReasoningContentPart[];
+  summary: SummaryTextPart[];
+}
+
+type MutableItem =
+  | MutableMessageItem
+  | MutableFunctionCallItem
+  | MutableFunctionCallOutputItem
+  | MutableReasoningItem;
 
 const duplicateTerminalError = (target: string): never => {
   throw invalidRequest(`${target} already received a terminal event`);
 };
 
-const asOutputTextPart = (part: MutableTextPart): CanonicalOutputTextPart => {
+const asOutputTextPart = (part: MutableOutputTextPart): CanonicalOutputTextPart => {
   return {
     type: "output_text",
     text: part.text,
-    annotations: [],
+    annotations: structuredClone(
+      part.annotations
+    ) as CanonicalOutputTextPart["annotations"],
+    logprobs: [],
   };
+};
+
+const asRefusalPart = (part: MutableRefusalPart): CanonicalRefusalPart => {
+  return {
+    type: "refusal",
+    refusal: part.refusal,
+  };
+};
+
+const asMessagePart = (part: MutableMessagePart): MessagePart => {
+  return part.kind === "output_text" ? asOutputTextPart(part) : asRefusalPart(part);
 };
 
 const asMessageItem = (item: MutableMessageItem): CanonicalMessageItem => {
@@ -86,7 +178,7 @@ const asMessageItem = (item: MutableMessageItem): CanonicalMessageItem => {
     type: "message",
     role: "assistant",
     status: item.status,
-    content: item.content.map(asOutputTextPart),
+    content: item.content.map(asMessagePart),
   };
 };
 
@@ -103,10 +195,42 @@ const asFunctionCallItem = (
   };
 };
 
+const asFunctionCallOutputItem = (
+  item: MutableFunctionCallOutputItem
+): CanonicalFunctionCallOutputItem => {
+  return {
+    id: item.id,
+    type: "function_call_output",
+    call_id: item.callId,
+    output: structuredClone(item.output) as CanonicalFunctionCallOutputItem["output"],
+    status: item.status,
+  };
+};
+
+const asReasoningItem = (
+  item: MutableReasoningItem
+): CanonicalReasoningItem => {
+  return {
+    id: item.id,
+    type: "reasoning",
+    ...(item.content.length > 0
+      ? { content: structuredClone(item.content) }
+      : {}),
+    summary: structuredClone(item.summary),
+  };
+};
+
 const asOutputItem = (item: MutableItem): CanonicalOutputItem => {
-  return item.kind === "message"
-    ? asMessageItem(item)
-    : asFunctionCallItem(item);
+  switch (item.kind) {
+    case "message":
+      return asMessageItem(item);
+    case "function_call":
+      return asFunctionCallItem(item);
+    case "function_call_output":
+      return asFunctionCallOutputItem(item);
+    case "reasoning":
+      return asReasoningItem(item);
+  }
 };
 
 const duplicateItemIdError = (itemId: string): never => {
@@ -128,19 +252,132 @@ class DefaultCanonicalItemAccumulator implements CanonicalItemAccumulator {
     }
   }
 
-  startMessageItem(input?: { id?: string }): CanonicalMessageItem {
+  #addItem(item: MutableItem): void {
+    this.#assertUniqueItemId(item.id);
+    this.#items.push(item);
+    this.#itemsById.set(item.id, item);
+  }
+
+  startTextMessageItem(input?: { id?: string }): CanonicalMessageItem {
     const item: MutableMessageItem = {
       kind: "message",
       id: input?.id ?? this.#generateId(),
       status: "in_progress",
       finalized: false,
-      content: [],
+      content: [
+        {
+          kind: "output_text",
+          text: "",
+          annotations: [],
+          finalized: false,
+        },
+      ],
     };
 
-    this.#assertUniqueItemId(item.id);
-    this.#items.push(item);
-    this.#itemsById.set(item.id, item);
+    this.#addItem(item);
+    return asMessageItem(item);
+  }
 
+  startMessageItem(input?: { id?: string }): CanonicalMessageItem {
+    return this.startTextMessageItem(input);
+  }
+
+  startRefusalMessageItem(input?: { id?: string }): CanonicalMessageItem {
+    const item: MutableMessageItem = {
+      kind: "message",
+      id: input?.id ?? this.#generateId(),
+      status: "in_progress",
+      finalized: false,
+      content: [
+        {
+          kind: "refusal",
+          refusal: "",
+          finalized: false,
+        },
+      ],
+    };
+
+    this.#addItem(item);
+    return asMessageItem(item);
+  }
+
+  startOutputTextPart(itemId: string): CanonicalOutputTextPart {
+    return asOutputTextPart(this.#getOutputTextPart(itemId));
+  }
+
+  appendOutputTextDelta(
+    itemId: string,
+    contentIndexOrDelta: number | string,
+    delta?: string
+  ): void {
+    const part = this.#getOutputTextPart(itemId);
+    if (part.finalized) {
+      duplicateTerminalError(`output text part for canonical item '${itemId}'`);
+    }
+
+    const nextDelta =
+      typeof contentIndexOrDelta === "string" ? contentIndexOrDelta : (delta ?? "");
+    part.text += nextDelta;
+  }
+
+  appendRefusalDelta(itemId: string, delta: string): void {
+    const part = this.#getRefusalPart(itemId);
+    if (part.finalized) {
+      duplicateTerminalError(`refusal part for canonical item '${itemId}'`);
+    }
+
+    part.refusal += delta;
+  }
+
+  addOutputTextAnnotation(itemId: string, annotation: Record<string, unknown>): void {
+    const part = this.#getOutputTextPart(itemId);
+    part.annotations.push(structuredClone(annotation));
+  }
+
+  finalizeOutputTextPart(
+    itemId: string,
+    _contentIndex = 0
+  ): CanonicalOutputTextPart {
+    const part = this.#getOutputTextPart(itemId);
+    if (part.finalized) {
+      duplicateTerminalError(`output text part for canonical item '${itemId}'`);
+    }
+    part.finalized = true;
+    return asOutputTextPart(part);
+  }
+
+  finalizeItem(
+    itemId: string,
+    status: "completed" | "incomplete"
+  ): CanonicalOutputItem {
+    const item = this.#getItem(itemId);
+    switch (item.kind) {
+      case "message":
+        return this.finalizeMessageItem(itemId, status);
+      case "function_call":
+        return this.finalizeFunctionCallItem(itemId, status);
+      case "reasoning":
+        return this.finalizeReasoningItem(itemId, status);
+      case "function_call_output":
+        return asFunctionCallOutputItem(item);
+    }
+  }
+
+  finalizeMessageItem(
+    itemId: string,
+    status: "completed" | "incomplete"
+  ): CanonicalMessageItem {
+    const item = this.#getMessageItem(itemId);
+    if (item.finalized) {
+      duplicateTerminalError(`canonical item '${itemId}'`);
+    }
+
+    for (const part of item.content) {
+      part.finalized = true;
+    }
+
+    item.finalized = true;
+    item.status = status;
     return asMessageItem(item);
   }
 
@@ -160,42 +397,8 @@ class DefaultCanonicalItemAccumulator implements CanonicalItemAccumulator {
       finalized: false,
     };
 
-    this.#assertUniqueItemId(item.id);
-    this.#items.push(item);
-    this.#itemsById.set(item.id, item);
-
+    this.#addItem(item);
     return asFunctionCallItem(item);
-  }
-
-  startOutputTextPart(itemId: string): CanonicalOutputTextPart {
-    const item = this.#getMessageItem(itemId);
-    this.#assertItemOpen(item);
-
-    const part: MutableTextPart = {
-      type: "output_text",
-      status: "in_progress",
-      text: "",
-      finalized: false,
-    };
-
-    item.content.push(part);
-
-    return asOutputTextPart(part);
-  }
-
-  appendOutputTextDelta(
-    itemId: string,
-    contentIndex: number,
-    delta: string
-  ): void {
-    const part = this.#getTextPart(itemId, contentIndex);
-    if (part.finalized) {
-      duplicateTerminalError(
-        `output text part ${contentIndex} for canonical item '${itemId}'`
-      );
-    }
-
-    part.text += delta;
   }
 
   appendFunctionCallArgumentsDelta(itemId: string, delta: string): void {
@@ -204,46 +407,113 @@ class DefaultCanonicalItemAccumulator implements CanonicalItemAccumulator {
     item.arguments += delta;
   }
 
-  finalizeOutputTextPart(
-    itemId: string,
-    contentIndex: number
-  ): CanonicalOutputTextPart {
-    const part = this.#getTextPart(itemId, contentIndex);
-    if (part.finalized) {
-      duplicateTerminalError(
-        `output text part ${contentIndex} for canonical item '${itemId}'`
-      );
-    }
-
-    part.finalized = true;
-    part.status = "completed";
-
-    return asOutputTextPart(part);
-  }
-
-  finalizeItem(
+  finalizeFunctionCallItem(
     itemId: string,
     status: "completed" | "incomplete"
-  ): CanonicalOutputItem {
-    const item = this.#getItem(itemId);
+  ): CanonicalFunctionCallItem {
+    const item = this.#getFunctionCallItem(itemId);
     if (item.finalized) {
       duplicateTerminalError(`canonical item '${itemId}'`);
     }
 
-    if (item.kind === "message") {
-      for (const [index, part] of item.content.entries()) {
-        if (!part.finalized) {
-          throw invalidRequest(
-            `Cannot finalize canonical item '${itemId}' before output text part ${index} is closed`
-          );
-        }
-      }
+    item.finalized = true;
+    item.status = status;
+    return asFunctionCallItem(item);
+  }
+
+  addFunctionCallOutputItem(input: {
+    callId: string;
+    output: string | Record<string, unknown>[];
+    id?: string;
+    status?: "completed" | "incomplete";
+  }): CanonicalFunctionCallOutputItem {
+    const item: MutableFunctionCallOutputItem = {
+      kind: "function_call_output",
+      id: input.id ?? this.#generateId(),
+      callId: input.callId,
+      output: structuredClone(input.output),
+      status: input.status ?? "completed",
+      finalized: true,
+    };
+
+    this.#addItem(item);
+    return asFunctionCallOutputItem(item);
+  }
+
+  startReasoningItem(input?: { id?: string }): CanonicalReasoningItem {
+    const item: MutableReasoningItem = {
+      kind: "reasoning",
+      id: input?.id ?? this.#generateId(),
+      status: "in_progress",
+      finalized: false,
+      content: [{ type: "reasoning_text", text: "" }],
+      summary: [],
+    };
+
+    this.#addItem(item);
+    return asReasoningItem(item);
+  }
+
+  appendReasoningDelta(itemId: string, delta: string): void {
+    const item = this.#getReasoningItem(itemId);
+    this.#assertItemOpen(item);
+    const part = item.content[0];
+    if (!part) {
+      item.content.push({ type: "reasoning_text", text: delta });
+      return;
+    }
+
+    part.text += delta;
+  }
+
+  appendReasoningSummary(itemId: string, text: string): void {
+    const item = this.#getReasoningItem(itemId);
+    const lastSummary = item.summary.at(-1);
+    if (lastSummary) {
+      lastSummary.text += text;
+      return;
+    }
+
+    item.summary.push({ type: "summary_text", text });
+  }
+
+  finalizeReasoningItem(
+    itemId: string,
+    status: "completed" | "incomplete" = "completed"
+  ): CanonicalReasoningItem {
+    const item = this.#getReasoningItem(itemId);
+    if (item.finalized) {
+      duplicateTerminalError(`canonical item '${itemId}'`);
     }
 
     item.finalized = true;
     item.status = status;
+    return asReasoningItem(item);
+  }
 
-    return asOutputItem(item);
+  finalizeOpenItemsAsIncomplete(): CanonicalOutputItem[] {
+    const finalized: CanonicalOutputItem[] = [];
+    for (const item of this.#items) {
+      if ("finalized" in item && item.finalized) {
+        continue;
+      }
+
+      if (item.kind === "message") {
+        finalized.push(this.finalizeMessageItem(item.id, "incomplete"));
+        continue;
+      }
+
+      if (item.kind === "function_call") {
+        finalized.push(this.finalizeFunctionCallItem(item.id, "incomplete"));
+        continue;
+      }
+
+      if (item.kind === "reasoning") {
+        finalized.push(this.finalizeReasoningItem(item.id, "incomplete"));
+      }
+    }
+
+    return finalized;
   }
 
   snapshot(): CanonicalOutputItem[] {
@@ -279,19 +549,42 @@ class DefaultCanonicalItemAccumulator implements CanonicalItemAccumulator {
     return item;
   }
 
-  #getTextPart(itemId: string, contentIndex: number): MutableTextPart {
+  #getReasoningItem(itemId: string): MutableReasoningItem {
+    const item = this.#getItem(itemId);
+    if (item.kind !== "reasoning") {
+      throw invalidRequest(`Canonical item '${itemId}' is not a reasoning item`);
+    }
+
+    return item;
+  }
+
+  #getOutputTextPart(itemId: string): MutableOutputTextPart {
     const item = this.#getMessageItem(itemId);
-    const part = item.content[contentIndex];
-    if (!part) {
+    const part = item.content[0];
+    if (!part || part.kind !== "output_text") {
       throw invalidRequest(
-        `Canonical item '${itemId}' does not contain output text part ${contentIndex}`
+        `Canonical item '${itemId}' does not contain an output_text part`
       );
     }
 
     return part;
   }
 
-  #assertItemOpen(item: MutableItem): void {
+  #getRefusalPart(itemId: string): MutableRefusalPart {
+    const item = this.#getMessageItem(itemId);
+    const part = item.content[0];
+    if (!part || part.kind !== "refusal") {
+      throw invalidRequest(
+        `Canonical item '${itemId}' does not contain a refusal part`
+      );
+    }
+
+    return part;
+  }
+
+  #assertItemOpen(
+    item: MutableMessageItem | MutableFunctionCallItem | MutableReasoningItem
+  ): void {
     if (item.finalized || item.status !== "in_progress") {
       duplicateTerminalError(`canonical item '${item.id}'`);
     }

--- a/packages/openresponses-adapter/src/state/response-aggregate.ts
+++ b/packages/openresponses-adapter/src/state/response-aggregate.ts
@@ -11,7 +11,6 @@ const normalizeTimestamp = (value: number | null): number | null => {
     return null;
   }
 
-  // Default clocks still commonly provide Date.now() millisecond values.
   if (value >= 1_000_000_000_000) {
     return Math.floor(value / 1000);
   }
@@ -33,50 +32,16 @@ const normalizeError = (
   return {
     code: error.code,
     message: error.message,
+    type: error.type,
+    ...(error.param !== undefined ? { param: error.param } : {}),
   };
 };
 
 const normalizeOutput = (output: unknown[]): unknown[] => {
-  return output.map((item) => {
-    if (
-      typeof item !== "object" ||
-      item === null ||
-      !("type" in item) ||
-      item.type !== "message"
-    ) {
-      return clone(item);
-    }
-
-    const messageItem = item as Record<string, unknown>;
-    const content = Array.isArray(messageItem.content)
-      ? messageItem.content
-      : [];
-
-    return {
-      ...clone(messageItem),
-      content: content.map((part) => {
-        if (
-          typeof part === "object" &&
-          part !== null &&
-          "type" in part &&
-          part.type === "output_text"
-        ) {
-          return {
-            ...clone(part),
-            annotations: Array.isArray(part.annotations)
-              ? clone(part.annotations)
-              : [],
-            logprobs: Array.isArray(part.logprobs) ? clone(part.logprobs) : [],
-          };
-        }
-
-        return clone(part);
-      }),
-    };
-  });
+  return clone(output);
 };
 
-export interface TerminalResponseMaterializationParams {
+export interface ResponseSnapshotMaterializationParams {
   request: OpenResponsesRequestSnapshot;
   responseId: string;
   createdAt: number;
@@ -84,12 +49,12 @@ export interface TerminalResponseMaterializationParams {
   status: OpenResponsesResponse["status"];
   output: unknown[];
   error: ErrorObject | null;
-  incompleteDetails?: unknown;
-  usage?: unknown;
+  incompleteDetails?: OpenResponsesResponse["incomplete_details"];
+  usage?: OpenResponsesResponse["usage"];
 }
 
-export const materializeTerminalResponse = (
-  params: TerminalResponseMaterializationParams
+export const materializeResponseSnapshot = (
+  params: ResponseSnapshotMaterializationParams
 ): OpenResponsesResponse => {
   const response = {
     id: params.responseId,
@@ -99,7 +64,7 @@ export const materializeTerminalResponse = (
     status: params.status,
     incomplete_details:
       params.status === "incomplete"
-        ? (params.incompleteDetails ?? { reason: "max_output_tokens" })
+        ? (params.incompleteDetails ?? { reason: "stream_ended_before_terminal_state" })
         : null,
     model: params.request.model,
     previous_response_id: params.request.previous_response_id,
@@ -131,4 +96,13 @@ export const materializeTerminalResponse = (
   };
 
   return OpenResponsesResponseSchema.parse(response);
+};
+
+export type TerminalResponseMaterializationParams =
+  ResponseSnapshotMaterializationParams;
+
+export const materializeTerminalResponse = (
+  params: TerminalResponseMaterializationParams
+): OpenResponsesResponse => {
+  return materializeResponseSnapshot(params);
 };

--- a/packages/openresponses-adapter/src/state/response-aggregate.ts
+++ b/packages/openresponses-adapter/src/state/response-aggregate.ts
@@ -64,7 +64,9 @@ export const materializeResponseSnapshot = (
     status: params.status,
     incomplete_details:
       params.status === "incomplete"
-        ? (params.incompleteDetails ?? { reason: "stream_ended_before_terminal_state" })
+        ? (params.incompleteDetails ?? {
+            reason: "stream_ended_before_terminal_state",
+          })
         : null,
     model: params.request.model,
     previous_response_id: params.request.previous_response_id,

--- a/packages/openresponses-adapter/src/state/response-lifecycle.ts
+++ b/packages/openresponses-adapter/src/state/response-lifecycle.ts
@@ -1,5 +1,5 @@
 import { invalidRequest } from "@/core/errors.js";
-import type { ErrorObject } from "@/core/internal-schemas.js";
+import type { ErrorObject } from "@/core/schemas.js";
 
 export type ResponseLifecycleStatus =
   | "queued"

--- a/packages/openresponses-adapter/tests/compliance.spec.ts
+++ b/packages/openresponses-adapter/tests/compliance.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
-  buildOpenResponsesApp,
-  createOpenResponsesAdapter,
+  buildOpenResponsesApp as buildOpenResponsesServerApp,
+  createOpenResponsesAdapter as createAdapter,
 } from "@/server/index.js";
 import {
   createFakeAgent,
@@ -32,7 +32,7 @@ const weatherTool = {
 
 describe("local compliance suite", () => {
   test("basic text response returns a response resource", async () => {
-    const app = await buildOpenResponsesApp({
+    const app = await buildOpenResponsesServerApp({
       agent: createFakeAgent(),
     });
 
@@ -57,7 +57,7 @@ describe("local compliance suite", () => {
   });
 
   test("streaming response returns SSE events and literal [DONE]", async () => {
-    const adapter = createOpenResponsesAdapter({
+    const adapter = createAdapter({
       agent: createCallbackDrivenAgent({ onStream: simulateTextStream }),
     });
 
@@ -66,14 +66,21 @@ describe("local compliance suite", () => {
     );
 
     expect(events[0]).toMatchObject({
-      type: "response.in_progress",
+      type: "response.created",
     });
+    expect(
+      events.some((event) => {
+        return (
+          typeof event !== "string" && event.type === "response.in_progress"
+        );
+      })
+    ).toBe(true);
     expect(events.at(-1)).toBe("[DONE]");
   });
 
   test("system prompt is preserved in the runtime input", async () => {
     const agent = createFakeAgent();
-    const app = await buildOpenResponsesApp({ agent });
+    const app = await buildOpenResponsesServerApp({ agent });
 
     await app.request("/v1/responses", {
       method: "POST",
@@ -107,7 +114,7 @@ describe("local compliance suite", () => {
   });
 
   test("tool calling produces function-call stream items", async () => {
-    const adapter = createOpenResponsesAdapter({
+    const adapter = createAdapter({
       agent: createCallbackDrivenAgent({ onStream: simulateToolCallStream }),
       toolPolicySupport: "middleware",
     });
@@ -132,7 +139,7 @@ describe("local compliance suite", () => {
 
   test("image input remains visible to the runtime", async () => {
     const agent = createFakeAgent();
-    const app = await buildOpenResponsesApp({ agent });
+    const app = await buildOpenResponsesServerApp({ agent });
 
     await app.request("/v1/responses", {
       method: "POST",
@@ -179,7 +186,7 @@ describe("local compliance suite", () => {
     await previousResponseStore.save(createPriorRecord());
 
     const agent = createFakeAgent();
-    const app = await buildOpenResponsesApp({
+    const app = await buildOpenResponsesServerApp({
       agent,
       previousResponseStore,
     });

--- a/packages/openresponses-adapter/tests/event-order.spec.ts
+++ b/packages/openresponses-adapter/tests/event-order.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { OpenResponsesEvent } from "@/core/internal-schemas.js";
+import type { OpenResponsesEvent } from "@/core/schemas.js";
 import { createOpenResponsesAdapter } from "@/server/index.js";
 import {
   createDeterministicClock,
@@ -33,6 +33,8 @@ describe("event order regression", () => {
     expect(
       events.map((event) => (typeof event === "string" ? event : event.type))
     ).toEqual([
+      "response.created",
+      "response.queued",
       "response.in_progress",
       "response.output_item.added",
       "response.content_part.added",
@@ -51,7 +53,7 @@ describe("event order regression", () => {
           (event): event is OpenResponsesEvent => typeof event !== "string"
         )
         .map((event) => event.sequence_number)
-    ).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    ).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
   });
 
   test("never emits response.completed after a failed stream", async () => {

--- a/packages/openresponses-adapter/tests/helpers/streaming-fixtures.ts
+++ b/packages/openresponses-adapter/tests/helpers/streaming-fixtures.ts
@@ -1,4 +1,4 @@
-import type { OpenResponsesEvent } from "@/core/internal-schemas.js";
+import type { OpenResponsesEvent } from "@/core/schemas.js";
 import type {
   LangChainMessageLike,
   OpenResponsesCompatibleAgent,

--- a/packages/openresponses-adapter/tests/tool-calling.spec.ts
+++ b/packages/openresponses-adapter/tests/tool-calling.spec.ts
@@ -92,9 +92,13 @@ describe("tool calling release blockers", () => {
     expect(
       events.map((event) => (typeof event === "string" ? event : event.type))
     ).toEqual([
+      "response.created",
+      "response.queued",
       "response.in_progress",
       "response.output_item.added",
       "response.function_call_arguments.done",
+      "response.output_item.done",
+      "response.output_item.added",
       "response.output_item.done",
       "response.completed",
       "[DONE]",

--- a/packages/openresponses-adapter/tests/unit/callback-bridge.test.ts
+++ b/packages/openresponses-adapter/tests/unit/callback-bridge.test.ts
@@ -927,4 +927,65 @@ describe("OpenResponsesCallbackBridge", () => {
       runId: "bounded-run-0",
     });
   });
+
+  test("keeps restarted terminal runs suppressing duplicates after retention eviction", async () => {
+    const { events, emitter } = createEmitter();
+    const bridge = createOpenResponsesCallbackBridge({
+      emitter,
+      generateId: createSequentialIdGenerator(["msg-restarted"]),
+    });
+
+    await callHandler(
+      bridge.handleChatModelStart,
+      serializedFixture,
+      [],
+      "run-restarted"
+    );
+    await callHandler(
+      bridge.handleLLMError,
+      new Error("first failure"),
+      "run-restarted"
+    );
+
+    await callHandler(
+      bridge.handleChatModelStart,
+      serializedFixture,
+      [],
+      "run-restarted"
+    );
+    await callHandler(
+      bridge.handleLLMError,
+      new Error("second failure"),
+      "run-restarted"
+    );
+
+    for (let index = 0; index < 255; index++) {
+      const runId = `retained-run-${index}`;
+      await callHandler(
+        bridge.handleChatModelStart,
+        serializedFixture,
+        [],
+        runId
+      );
+      await callHandler(
+        bridge.handleLLMError,
+        new Error(`failure-${index}`),
+        runId
+      );
+    }
+
+    const eventsBeforeDuplicateFailure = events.length;
+    await callHandler(
+      bridge.handleLLMError,
+      new Error("should stay suppressed"),
+      "run-restarted"
+    );
+
+    expect(events).toHaveLength(eventsBeforeDuplicateFailure);
+    expect(
+      events.filter((event) => {
+        return event.type === "run.failed" && event.runId === "run-restarted";
+      })
+    ).toHaveLength(2);
+  });
 });

--- a/packages/openresponses-adapter/tests/unit/callback-bridge.test.ts
+++ b/packages/openresponses-adapter/tests/unit/callback-bridge.test.ts
@@ -102,7 +102,7 @@ describe("OpenResponsesCallbackBridge", () => {
     const { events, emitter } = createEmitter();
     const bridge = createOpenResponsesCallbackBridge({
       emitter,
-      generateId: createSequentialIdGenerator(["fc-1"]),
+      generateId: createSequentialIdGenerator(["fc-1", "fc-out-1"]),
     });
 
     const actionWithDelta: AgentActionWithBridgeFields = {
@@ -158,6 +158,12 @@ describe("OpenResponsesCallbackBridge", () => {
         callId: "call-1",
       },
       { type: "function_call.completed", itemId: "fc-1" },
+      {
+        type: "function_call_output.completed",
+        itemId: "fc-out-1",
+        callId: "call-1",
+        output: '{"temperature":"55F"}',
+      },
       { type: "run.completed", runId: "agent-run-1" },
     ]);
   });
@@ -166,7 +172,7 @@ describe("OpenResponsesCallbackBridge", () => {
     const { events, emitter } = createEmitter();
     const bridge = createOpenResponsesCallbackBridge({
       emitter,
-      generateId: createSequentialIdGenerator(["fc-2"]),
+      generateId: createSequentialIdGenerator(["fc-2", "fc-out-2"]),
     });
 
     const actionWithoutDeltas: AgentActionWithBridgeFields = {
@@ -199,6 +205,12 @@ describe("OpenResponsesCallbackBridge", () => {
         callId: "call-2",
       },
       { type: "function_call.completed", itemId: "fc-2" },
+      {
+        type: "function_call_output.completed",
+        itemId: "fc-out-2",
+        callId: "call-2",
+        output: "ok",
+      },
     ]);
 
     expect(
@@ -210,7 +222,12 @@ describe("OpenResponsesCallbackBridge", () => {
     const { events, emitter } = createEmitter();
     const bridge = createOpenResponsesCallbackBridge({
       emitter,
-      generateId: createSequentialIdGenerator(["fc-1", "fc-2"]),
+      generateId: createSequentialIdGenerator([
+        "fc-1",
+        "fc-2",
+        "fc-out-2",
+        "fc-out-1",
+      ]),
     });
 
     const firstAction: AgentActionWithBridgeFields = {
@@ -293,6 +310,12 @@ describe("OpenResponsesCallbackBridge", () => {
       },
       { type: "function_call.completed", itemId: "fc-2" },
       {
+        type: "function_call_output.completed",
+        itemId: "fc-out-2",
+        callId: "call-2",
+        output: '{"now":"10:00"}',
+      },
+      {
         type: "tool.started",
         runId: "tool-run-1",
         toolName: "get_weather",
@@ -305,6 +328,12 @@ describe("OpenResponsesCallbackBridge", () => {
         callId: "call-1",
       },
       { type: "function_call.completed", itemId: "fc-1" },
+      {
+        type: "function_call_output.completed",
+        itemId: "fc-out-1",
+        callId: "call-1",
+        output: '{"temperature":"55F"}',
+      },
     ]);
   });
 
@@ -394,7 +423,7 @@ describe("OpenResponsesCallbackBridge", () => {
     const { events, emitter } = createEmitter();
     const bridge = createOpenResponsesCallbackBridge({
       emitter,
-      generateId: createSequentialIdGenerator(["fc-3"]),
+      generateId: createSequentialIdGenerator(["fc-3", "fc-out-3"]),
     });
 
     const actionWithoutCallId: AgentAction = {
@@ -443,6 +472,12 @@ describe("OpenResponsesCallbackBridge", () => {
         callId: "real-call-5",
       },
       { type: "function_call.completed", itemId: "fc-3" },
+      {
+        type: "function_call_output.completed",
+        itemId: "fc-out-3",
+        callId: "real-call-5",
+        output: "ok",
+      },
     ]);
   });
 
@@ -450,7 +485,12 @@ describe("OpenResponsesCallbackBridge", () => {
     const { events, emitter } = createEmitter();
     const bridge = createOpenResponsesCallbackBridge({
       emitter,
-      generateId: createSequentialIdGenerator(["fc-4", "fc-5"]),
+      generateId: createSequentialIdGenerator([
+        "fc-4",
+        "fc-5",
+        "fc-out-5",
+        "fc-out-4",
+      ]),
     });
 
     const firstAction: AgentAction = {
@@ -526,6 +566,12 @@ describe("OpenResponsesCallbackBridge", () => {
       },
       { type: "function_call.completed", itemId: "fc-5" },
       {
+        type: "function_call_output.completed",
+        itemId: "fc-out-5",
+        callId: "fc-5",
+        output: '{"now":"10:00"}',
+      },
+      {
         type: "function_call.started",
         itemId: "fc-4",
         name: "get_weather",
@@ -545,6 +591,12 @@ describe("OpenResponsesCallbackBridge", () => {
         callId: "fc-4",
       },
       { type: "function_call.completed", itemId: "fc-4" },
+      {
+        type: "function_call_output.completed",
+        itemId: "fc-out-4",
+        callId: "fc-4",
+        output: '{"temperature":"55F"}',
+      },
     ]);
   });
 
@@ -552,7 +604,10 @@ describe("OpenResponsesCallbackBridge", () => {
     const { events, emitter } = createEmitter();
     const bridge = createOpenResponsesCallbackBridge({
       emitter,
-      generateId: createSequentialIdGenerator(["fc-tool-only"]),
+      generateId: createSequentialIdGenerator([
+        "fc-tool-only",
+        "fc-tool-only-out",
+      ]),
     });
 
     const action: AgentActionWithBridgeFields = {
@@ -615,6 +670,12 @@ describe("OpenResponsesCallbackBridge", () => {
         callId: "call-tool-only",
       },
       { type: "function_call.completed", itemId: "fc-tool-only" },
+      {
+        type: "function_call_output.completed",
+        itemId: "fc-tool-only-out",
+        callId: "call-tool-only",
+        output: "ok",
+      },
       { type: "run.completed", runId: "tool-only-run" },
     ]);
   });

--- a/packages/openresponses-adapter/tests/unit/event-serializer.test.ts
+++ b/packages/openresponses-adapter/tests/unit/event-serializer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { InternalSemanticEvent } from "@/core/events.js";
-import type { OpenResponsesEvent } from "@/core/internal-schemas.js";
+import type { OpenResponsesEvent } from "@/core/schemas.js";
 import {
   createEventSerializer,
   createSequenceGenerator,
@@ -16,6 +16,34 @@ import {
   createDeterministicClock,
   createSequentialIdGenerator,
 } from "@/testing/index.js";
+
+const createRequestSnapshot = () => ({
+  model: "test-model",
+  input: [],
+  previous_response_id: null,
+  include: [],
+  tools: [],
+  tool_choice: "auto" as const,
+  parallel_tool_calls: true,
+  instructions: null,
+  store: false,
+  background: false,
+  truncation: "disabled" as const,
+  text: { format: { type: "text" as const }, verbosity: "medium" as const },
+  reasoning: null,
+  top_p: 1,
+  presence_penalty: 0,
+  frequency_penalty: 0,
+  top_logprobs: 0,
+  temperature: 1,
+  max_output_tokens: null,
+  max_tool_calls: null,
+  service_tier: "default" as const,
+  safety_identifier: null,
+  prompt_cache_key: null,
+  metadata: {},
+  stream_options: null,
+});
 
 const createContext = (
   overrides: Partial<SerializerContext> = {}
@@ -35,6 +63,7 @@ const createContext = (
       createdAt: 1000,
       clock: createDeterministicClock(2000),
     }),
+    request: createRequestSnapshot(),
     inProgressEmitted: { value: false },
     itemOutputIndices: new Map(),
     ...overrides,
@@ -77,7 +106,7 @@ describe("serializeInternalEvent", () => {
       sequence_number: 1,
       response: { id: "resp-1", object: "response", status: "in_progress" },
     });
-    expect(context.inProgressEmitted.value).toBe(true);
+    expect(context.inProgressEmitted?.value).toBe(true);
     expect(context.lifecycle.getStatus()).toBe("in_progress");
   });
 
@@ -417,11 +446,15 @@ describe("serializeInternalEvent", () => {
     );
 
     expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({
-      type: "response.failed",
-      response: { id: "resp-1", object: "response", status: "failed" },
-      error: { type: "model_error", message: "boom" },
-    });
+    expect(events[0]?.type).toBe("response.failed");
+    if (events[0]?.type === "response.failed") {
+      expect(events[0].response.id).toBe("resp-1");
+      expect(events[0].response.status).toBe("failed");
+      expect(events[0].response.error).toMatchObject({
+        type: "model_error",
+        message: "boom",
+      });
+    }
   });
 
   test("run.failed from a sub-run does not fail the response lifecycle", () => {
@@ -527,12 +560,12 @@ describe("createEventSerializer", () => {
 
     const events = await collectEvents(serializer);
 
-    // Expected: in_progress, item.added, part.added, delta, delta,
-    //   text.done, part.done, item.done, completed, [DONE]
-    expect(events).toHaveLength(10);
+    expect(events).toHaveLength(12);
 
     const types = events.map((e) => (typeof e === "string" ? e : e.type));
     expect(types).toEqual([
+      "response.created",
+      "response.queued",
       "response.in_progress",
       "response.output_item.added",
       "response.content_part.added",
@@ -545,11 +578,11 @@ describe("createEventSerializer", () => {
       "[DONE]",
     ]);
 
-    // Verify sequence numbers are 1..9
+    // Verify sequence numbers are 1..11
     const seqNums = events
       .filter((e): e is OpenResponsesEvent => typeof e !== "string")
       .map((e) => e.sequence_number);
-    expect(seqNums).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(seqNums).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
   });
 
   test("queue failure emits response.failed + [DONE]", async () => {
@@ -578,6 +611,8 @@ describe("createEventSerializer", () => {
 
     const types = events.map((e) => (typeof e === "string" ? e : e.type));
     expect(types).toEqual([
+      "response.created",
+      "response.queued",
       "response.in_progress",
       "response.output_item.added",
       "response.content_part.added",
@@ -618,6 +653,8 @@ describe("createEventSerializer", () => {
 
     const types = events.map((e) => (typeof e === "string" ? e : e.type));
     expect(types).toEqual([
+      "response.created",
+      "response.queued",
       "response.in_progress",
       "response.output_item.added",
       "response.content_part.added",
@@ -633,7 +670,39 @@ describe("formatSSEFrame", () => {
     const event: OpenResponsesEvent = {
       type: "response.in_progress",
       sequence_number: 1,
-      response: { id: "resp-1", object: "response", status: "in_progress" },
+      response: {
+        id: "resp-1",
+        object: "response",
+        created_at: 1,
+        completed_at: null,
+        status: "in_progress",
+        incomplete_details: null,
+        model: "test-model",
+        previous_response_id: null,
+        instructions: null,
+        output: [],
+        error: null,
+        tools: [],
+        tool_choice: "auto",
+        truncation: "disabled",
+        parallel_tool_calls: true,
+        text: { format: { type: "text" }, verbosity: "medium" },
+        top_p: 1,
+        presence_penalty: 0,
+        frequency_penalty: 0,
+        top_logprobs: 0,
+        temperature: 1,
+        reasoning: null,
+        usage: null,
+        max_output_tokens: null,
+        max_tool_calls: null,
+        store: false,
+        background: false,
+        service_tier: "default",
+        metadata: {},
+        safety_identifier: null,
+        prompt_cache_key: null,
+      },
     };
 
     const frame = formatSSEFrame(event);

--- a/packages/openresponses-adapter/tests/unit/item-accumulator.test.ts
+++ b/packages/openresponses-adapter/tests/unit/item-accumulator.test.ts
@@ -103,6 +103,27 @@ describe("CanonicalItemAccumulator", () => {
     });
   });
 
+  test("stores distinct reasoning summaries as separate summary_text parts", () => {
+    const accumulator = createCanonicalItemAccumulator({
+      generateId: createSequentialIdGenerator(["reasoning-1"]),
+    });
+
+    const item = accumulator.startReasoningItem();
+    accumulator.appendReasoningDelta(item.id, "Need to compare options.");
+    accumulator.appendReasoningSummary(item.id, "Summary A");
+    accumulator.appendReasoningSummary(item.id, "Summary B");
+
+    expect(accumulator.finalizeReasoningItem(item.id)).toEqual({
+      id: "reasoning-1",
+      type: "reasoning",
+      content: [{ type: "reasoning_text", text: "Need to compare options." }],
+      summary: [
+        { type: "summary_text", text: "Summary A" },
+        { type: "summary_text", text: "Summary B" },
+      ],
+    });
+  });
+
   test("rejects duplicate caller-supplied item ids", () => {
     const accumulator = createCanonicalItemAccumulator({
       generateId: createSequentialIdGenerator(["generated-1"]),

--- a/packages/openresponses-adapter/tests/unit/item-accumulator.test.ts
+++ b/packages/openresponses-adapter/tests/unit/item-accumulator.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
+import type { MessageOutputItem } from "@/core/schemas.js";
 import { createCanonicalItemAccumulator } from "@/state/item-accumulator.js";
 import { createSequentialIdGenerator } from "@/testing/deterministic-id.js";
 
-const PART_CLOSED_PATTERN = /before output text part 0 is closed/;
 const DUPLICATE_ITEM_ID_PATTERN = /already exists/;
 const DUPLICATE_TERMINAL_PATTERN = /already received a terminal event/;
 
@@ -29,13 +29,14 @@ describe("CanonicalItemAccumulator", () => {
             type: "output_text",
             text: "Hello world",
             annotations: [],
+            logprobs: [],
           },
         ],
       },
     ]);
   });
 
-  test("closes output text parts before items", () => {
+  test("finalizes message items and returns the completed text payload", () => {
     const accumulator = createCanonicalItemAccumulator({
       generateId: createSequentialIdGenerator(["msg-1"]),
     });
@@ -44,15 +45,18 @@ describe("CanonicalItemAccumulator", () => {
     accumulator.startOutputTextPart(item.id);
     accumulator.appendOutputTextDelta(item.id, 0, "Hello");
 
-    expect(() => accumulator.finalizeItem(item.id, "completed")).toThrow(
-      PART_CLOSED_PATTERN
-    );
-
     const part = accumulator.finalizeOutputTextPart(item.id, 0);
     const finalizedItem = accumulator.finalizeItem(item.id, "completed");
+    const finalizedMessage = finalizedItem as MessageOutputItem;
 
     expect(part.text).toBe("Hello");
-    expect(finalizedItem.status).toBe("completed");
+    expect(finalizedMessage.status).toBe("completed");
+    expect(finalizedMessage.content[0]).toEqual({
+      type: "output_text",
+      text: "Hello",
+      annotations: [],
+      logprobs: [],
+    });
   });
 
   test("rejects duplicate terminal events for the same text part and item", () => {

--- a/packages/openresponses-adapter/tests/unit/streaming.test.ts
+++ b/packages/openresponses-adapter/tests/unit/streaming.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { OpenResponsesEvent } from "@/core/internal-schemas.js";
+import type { OpenResponsesEvent } from "@/core/schemas.js";
 import type {
   LangChainMessageLike,
   OpenResponsesCompatibleAgent,
@@ -248,16 +248,14 @@ const collectStream = async (
 const extractResponseId = (
   events: (OpenResponsesEvent | "[DONE]")[]
 ): string => {
-  const firstEvent = events[0];
-  if (
-    !firstEvent ||
-    typeof firstEvent === "string" ||
-    firstEvent.type !== "response.in_progress"
-  ) {
-    throw new Error("Expected first stream event to be response.in_progress");
+  const inProgressEvent = events.find((event) => {
+    return typeof event !== "string" && event.type === "response.in_progress";
+  });
+  if (!inProgressEvent || typeof inProgressEvent === "string") {
+    throw new Error("Expected stream to emit response.in_progress");
   }
 
-  return firstEvent.response.id;
+  return inProgressEvent.response.id;
 };
 
 const createDelayedStore = (params: {
@@ -383,6 +381,8 @@ describe("adapter.stream()", () => {
 
     const types = events.map((e) => (typeof e === "string" ? e : e.type));
     expect(types).toEqual([
+      "response.created",
+      "response.queued",
       "response.in_progress",
       "response.output_item.added",
       "response.content_part.added",
@@ -395,14 +395,16 @@ describe("adapter.stream()", () => {
       "[DONE]",
     ]);
 
-    // Verify sequence numbers are strictly incrementing 1..9
+    // Verify sequence numbers are strictly incrementing 1..11
     const seqNums = events
       .filter((e): e is OpenResponsesEvent => typeof e !== "string")
       .map((e) => e.sequence_number);
-    expect(seqNums).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    expect(seqNums).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 
     // Verify response ID is consistent
-    const inProgressEvent = events[0] as OpenResponsesEvent & {
+    const inProgressEvent = events.find((event) => {
+      return typeof event !== "string" && event.type === "response.in_progress";
+    }) as OpenResponsesEvent & {
       response: { id: string };
     };
     expect(inProgressEvent.response.id).toBe("resp-1");
@@ -521,7 +523,12 @@ describe("adapter.stream()", () => {
 
     expect(
       events.map((event) => (typeof event === "string" ? event : event.type))
-    ).toEqual(["response.failed", "[DONE]"]);
+    ).toEqual([
+      "response.created",
+      "response.queued",
+      "response.failed",
+      "[DONE]",
+    ]);
   });
 
   test("streaming completion persists a response record for continuation", async () => {
@@ -657,6 +664,8 @@ describe("adapter.stream()", () => {
     );
 
     expect(types).toEqual([
+      "response.created",
+      "response.queued",
       "response.in_progress",
       "response.output_item.added",
       "response.content_part.added",
@@ -666,6 +675,8 @@ describe("adapter.stream()", () => {
       "response.output_item.done",
       "response.output_item.added",
       "response.function_call_arguments.done",
+      "response.output_item.done",
+      "response.output_item.added",
       "response.output_item.done",
       "response.completed",
       "[DONE]",


### PR DESCRIPTION
## Summary
- implement Epic C streaming fidelity expansion for the OpenResponses adapter
- switch streaming/public event handling to the snapshot-backed schemas and add the ORA-C001 truthful publication note
- extend the callback bridge, semantic events, canonical accumulator, and terminal response materialization for richer streaming families and full terminal resources
- publish full lifecycle resources in terminal SSE events, preserve compliant ordering, and refresh regression coverage for the lifecycle prelude and function-call output behavior

## Verification
- bun test
- bun run test:compliance:official

## Notes
- official compliance runner now passes 6/6, including the streaming-response scenario
- checked in publication boundaries note: docs/spikes/ORA-C001-truthful-publication-boundaries.md
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skroyc/langchain-middlewares-callbacks-ts/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
