### PR TITLE
Add JSON-surface OpenResponses spec conformance harness and streaming proof

### DIFF
--- a/packages/openresponses-adapter/README.md
+++ b/packages/openresponses-adapter/README.md
@@ -6,7 +6,7 @@ It exposes a `POST /v1/responses` route, preserves `previous_response_id` replay
 
 ## Status
 
-This package targets conformance with the pinned OpenResponses snapshot for the JSON request surface, uses the official OpenResponses CLI runner as a baseline release gate, and adds a package-owned spec-conformance suite for runner-uncovered behaviors.
+This package targets conformance with the pinned OpenResponses snapshot for the JSON request surface, uses the official OpenResponses CLI runner as a baseline release gate, and adds a package-owned spec-conformance suite for runner-uncovered behaviors. That suite also retains a small set of stricter package invariants where the pinned upstream wording is softer or leaves behavior unspecified.
 
 Implemented release-blocker capabilities:
 
@@ -107,7 +107,7 @@ The route is available at `POST /v1/responses`.
 
 Streaming output is derived from live LangChain callbacks observed during `agent.stream()`. The adapter does not replay the final answer as synthetic deltas.
 
-If the runtime fails after headers are already sent, the stream emits `response.failed` and then terminates. If a strict persistence failure happens after stream completion, the stream closes without appending `[DONE]`.
+If the runtime fails after headers are already sent, the stream emits `error`, then `response.failed`, and then terminates. If a strict persistence failure happens after stream completion, the stream closes without appending `[DONE]`.
 
 ### Compliance and release gating
 
@@ -118,6 +118,8 @@ Local regression tests, the official runner, and the spec-conformance suite are 
 - `bun run test:compliance:spec` runs the package-owned black-box JSON-surface conformance suite against the built package
 - `bun run test:compliance:full` runs the official runner and the package-owned conformance suite together
 - `bun run test:compliance` remains an alias to the local regression suite for backwards compatibility
+
+The package-owned suite intentionally includes a few stronger checks than the pinned upstream MUST-level wording, including omission of SSE `id` fields, monotonic built-in `sequence_number` progression, and package-specific HTTP/runtime error mappings where the upstream contract is silent.
 
 ### Tool policy enforcement
 

--- a/packages/openresponses-adapter/README.md
+++ b/packages/openresponses-adapter/README.md
@@ -138,6 +138,10 @@ Without that middleware, metadata-only tool policies still normalize, but enforc
 
 exactly in that order.
 
+### Item References
+
+`item_reference` is accepted as a schema-valid input item and preserved in the normalized request snapshot. The package does not currently invent dereference or re-hydration behavior for it at the LangChain runtime boundary, because the pinned public contract exposes the type more clearly than it defines its execution semantics.
+
 ### Image input
 
 `input_image` is accepted and passed through as-is. The package does not fetch, proxy, transform, or store image binaries.

--- a/packages/openresponses-adapter/README.md
+++ b/packages/openresponses-adapter/README.md
@@ -6,21 +6,22 @@ It exposes a `POST /v1/responses` route, preserves `previous_response_id` replay
 
 ## Status
 
-This package targets full compliance with the pinned OpenResponses snapshot, uses the official OpenResponses CLI runner as a baseline release gate, and treats broader pinned-spec conformance as a separate proof obligation.
+This package targets conformance with the pinned OpenResponses snapshot for the JSON request surface, uses the official OpenResponses CLI runner as a baseline release gate, and adds a package-owned spec-conformance suite for runner-uncovered behaviors.
 
 Implemented release-blocker capabilities:
 
 - Non-streaming full `ResponseResource` JSON responses
-- Streaming `text/event-stream` responses with semantic events, full terminal response payloads, and literal `[DONE]`
+- Streaming `text/event-stream` responses with semantic events, full terminal response payloads, literal `[DONE]`, and post-start `error` events
 - `previous_response_id` continuation through `PreviousResponseStore`
 - Tool-calling normalization and enforcement
 - `input_image` pass-through support
 - Package-local regressions separated from the official black-box compliance runner
+- Package-owned black-box spec-conformance checks for JSON-surface framing and runner gaps
 - Node 24 and Bun built-package smoke coverage for root, `./server`, and `./testing` entrypoints
 
 Deliberate boundaries:
 
-- `application/json` is the only accepted request-body encoding in this package overlay, even though the upstream vendored OpenAPI currently advertises a broader request-body surface
+- `application/json` is the only accepted request-body encoding in this package milestone, even though the upstream vendored OpenAPI currently advertises a broader request-body surface
 - No broad multimodal output support
 - No bundled durable persistence adapter
 - No synthetic text or function-call deltas when callbacks are too weak to support them truthfully
@@ -110,10 +111,12 @@ If the runtime fails after headers are already sent, the stream emits `response.
 
 ### Compliance and release gating
 
-Local regression tests and the official runner are intentionally separate:
+Local regression tests, the official runner, and the spec-conformance suite are intentionally separate:
 
 - `bun run test:compliance:local` covers package-owned regression scenarios
 - `bun run test:compliance:official` runs the vendored official OpenResponses CLI mirror against the built package
+- `bun run test:compliance:spec` runs the package-owned black-box JSON-surface conformance suite against the built package
+- `bun run test:compliance:full` runs the official runner and the package-owned conformance suite together
 - `bun run test:compliance` remains an alias to the local regression suite for backwards compatibility
 
 ### Tool policy enforcement
@@ -170,6 +173,8 @@ bun run test:golden-stream
 bun run test:compliance
 bun run test:compliance:local
 bun run test:compliance:official
+bun run test:compliance:spec
+bun run test:compliance:full
 bun run smoke:node
 bun run smoke:bun
 ```

--- a/packages/openresponses-adapter/contracts/openresponses/REQUIREMENT-MATRIX.md
+++ b/packages/openresponses-adapter/contracts/openresponses/REQUIREMENT-MATRIX.md
@@ -27,15 +27,20 @@ Scope notes:
 | OR-STREAM-003 | specification | Streaming terminates with literal `[DONE]` after the terminal event | shared | `streaming-response`, `sse-framing-and-ordering` | covered |
 | OR-STREAM-004 | reference/openapi | Terminal stream events carry the full `ResponseResource` | shared | `streaming-response`, `sse-framing-and-ordering` | covered |
 | OR-STREAM-005 | specification | Sequence numbers are monotonic across a response stream | spec_conformance | `sse-framing-and-ordering` | covered |
-| OR-STREAM-006 | specification | Stream lifecycle ordering begins `response.created -> response.queued -> response.in_progress` | spec_conformance | `sse-framing-and-ordering` | covered |
+| OR-STREAM-006 | specification | Stream lifecycle ordering begins `response.created -> response.queued -> response.in_progress` once live execution has actually started | spec_conformance | `sse-framing-and-ordering` | partial |
 | OR-STREAM-007 | specification + reference/openapi | Post-start failures emit an `error` event and resolve through terminal `response.failed` semantics | spec_conformance | `post-start-failure` | covered |
 | OR-STREAM-008 | reference/openapi | Incomplete executions emit `response.incomplete` and terminal incomplete state | spec_conformance | `incomplete-terminal` | covered |
 | OR-STREAM-009 | reference/openapi | Reasoning summary event families are emitted when reasoning summaries are present | spec_conformance | `reasoning-summary-coverage` | covered |
 | OR-CONT-001 | specification | Continuation semantics are keyed by `previous_response_id` and replay prior input before prior output before new input | official_runner | `multi-turn` plus existing continuation regressions | partial |
 | OR-TOOLS-001 | specification + reference/openapi | Tool-calling paths surface contract-valid function-call behavior | official_runner | `tool-calling` | partial |
 
-`partial` rows are intentionally called out because the official runner gives
-useful baseline coverage but does not fully prove the broader normative
-continuation and tool-governance contract on its own. Those rows should be the
-next candidates for black-box expansion if the package needs a stricter release
-claim than the current JSON-surface milestone.
+`partial` rows are intentionally called out because the current proof only
+covers a narrower slice of the normative contract than the row title implies.
+For `OR-STREAM-006`, the package proves the normal started-execution ordering,
+but queued-to-failed early stream failures currently emit
+`response.created -> response.queued -> error -> response.failed -> [DONE]`
+without an intervening `response.in_progress`. For `OR-CONT-001` and
+`OR-TOOLS-001`, the official runner gives useful baseline coverage but does not
+fully prove the broader continuation and tool-governance contract on its own.
+Those rows are the next candidates for black-box expansion if the package needs
+a stricter release claim than the current JSON-surface milestone.

--- a/packages/openresponses-adapter/contracts/openresponses/REQUIREMENT-MATRIX.md
+++ b/packages/openresponses-adapter/contracts/openresponses/REQUIREMENT-MATRIX.md
@@ -27,7 +27,7 @@ Scope notes:
 | OR-STREAM-003 | specification | Streaming terminates with literal `[DONE]` after the terminal event | shared | `streaming-response`, `sse-framing-and-ordering` | covered |
 | OR-STREAM-004 | reference/openapi | Terminal stream events carry the full `ResponseResource` | shared | `streaming-response`, `sse-framing-and-ordering` | covered |
 | OR-STREAM-005 | specification | Sequence numbers are monotonic across a response stream | spec_conformance | `sse-framing-and-ordering` | covered |
-| OR-STREAM-006 | specification | Stream lifecycle ordering begins `response.created -> response.queued -> response.in_progress` once live execution has actually started | spec_conformance | `sse-framing-and-ordering` | partial |
+| OR-STREAM-006 | specification | Stream lifecycle ordering begins `response.created -> response.queued -> response.in_progress` | spec_conformance | `sse-framing-and-ordering`, `post-start-failure` | covered |
 | OR-STREAM-007 | specification + reference/openapi | Post-start failures emit an `error` event and resolve through terminal `response.failed` semantics | spec_conformance | `post-start-failure` | covered |
 | OR-STREAM-008 | reference/openapi | Incomplete executions emit `response.incomplete` and terminal incomplete state | spec_conformance | `incomplete-terminal` | covered |
 | OR-STREAM-009 | reference/openapi | Reasoning summary event families are emitted when reasoning summaries are present | spec_conformance | `reasoning-summary-coverage` | covered |
@@ -36,11 +36,8 @@ Scope notes:
 
 `partial` rows are intentionally called out because the current proof only
 covers a narrower slice of the normative contract than the row title implies.
-For `OR-STREAM-006`, the package proves the normal started-execution ordering,
-but queued-to-failed early stream failures currently emit
-`response.created -> response.queued -> error -> response.failed -> [DONE]`
-without an intervening `response.in_progress`. For `OR-CONT-001` and
-`OR-TOOLS-001`, the official runner gives useful baseline coverage but does not
-fully prove the broader continuation and tool-governance contract on its own.
-Those rows are the next candidates for black-box expansion if the package needs
-a stricter release claim than the current JSON-surface milestone.
+For `OR-CONT-001` and `OR-TOOLS-001`, the official runner gives useful
+baseline coverage but does not fully prove the broader continuation and
+tool-governance contract on its own. Those rows are the next candidates for
+black-box expansion if the package needs a stricter release claim than the
+current JSON-surface milestone.

--- a/packages/openresponses-adapter/contracts/openresponses/REQUIREMENT-MATRIX.md
+++ b/packages/openresponses-adapter/contracts/openresponses/REQUIREMENT-MATRIX.md
@@ -23,17 +23,26 @@ Scope notes:
 | OR-HTTP-004 | reference/openapi | `application/x-www-form-urlencoded` is published upstream but deferred from this milestone by explicit scope | deferred_by_scope | user scope decision on 2026-03-26 | deferred |
 | OR-RESP-001 | reference/openapi | Terminal JSON responses contain the full `ResponseResource` shape, including nullable/defaulted fields | shared | `basic-response`, `response-resource-complete` | covered |
 | OR-STREAM-001 | specification | SSE `event` must match body `type` | spec_conformance | `sse-framing-and-ordering` | covered |
-| OR-STREAM-002 | specification | SSE frames must not use the `id` field | spec_conformance | `sse-framing-and-ordering` | covered |
+| OR-STREAM-002 | specification | SSE frames SHOULD NOT use the `id` field | spec_conformance | `sse-framing-and-ordering` | covered |
 | OR-STREAM-003 | specification | Streaming terminates with literal `[DONE]` after the terminal event | shared | `streaming-response`, `sse-framing-and-ordering` | covered |
 | OR-STREAM-004 | reference/openapi | Terminal stream events carry the full `ResponseResource` | shared | `streaming-response`, `sse-framing-and-ordering` | covered |
-| OR-STREAM-005 | specification | Sequence numbers are monotonic across a response stream | spec_conformance | `sse-framing-and-ordering` | covered |
-| OR-STREAM-006 | specification | Stream lifecycle ordering begins `response.created -> response.queued -> response.in_progress` | spec_conformance | `sse-framing-and-ordering`, `post-start-failure` | covered |
+| OR-STREAM-005 | reference/openapi | Built-in streaming events carry integer `sequence_number` fields | spec_conformance | `sse-framing-and-ordering` | covered |
+| OR-STREAM-006 | specification | The modeled stream lifecycle places `response.in_progress` before terminal `response.completed` / `response.failed` / `response.incomplete` states | spec_conformance | `sse-framing-and-ordering`, `post-start-failure` | covered |
 | OR-STREAM-007 | specification + reference/openapi | Post-start failures emit an `error` event and resolve through terminal `response.failed` semantics | spec_conformance | `post-start-failure` | covered |
 | OR-STREAM-008 | reference/openapi | Incomplete executions emit `response.incomplete` and terminal incomplete state | spec_conformance | `incomplete-terminal` | covered |
 | OR-STREAM-009 | reference/openapi | Reasoning summary event families are emitted when reasoning summaries are present | spec_conformance | `reasoning-summary-coverage` | covered |
 | OR-CONT-001 | specification | Continuation semantics are keyed by `previous_response_id` and replay prior input before prior output before new input | spec_conformance | `continuation-coverage` | covered |
-| OR-TOOLS-001 | specification + reference/openapi | Tool-calling paths surface contract-valid function-call behavior and tool-governance semantics | spec_conformance | `tool-governance-coverage` | covered |
+| OR-TOOLS-001 | specification + reference/openapi | The JSON request surface accepts published tool-governance request shapes (`tool_choice`, specific function choice, `allowed_tools`) and preserves tool contract fields in public request/response semantics | spec_conformance | `tool-governance-coverage` | covered |
 
 No in-scope JSON-surface requirement rows are intentionally left `partial`.
 The only remaining non-covered row is `OR-HTTP-004`, which is explicitly
 deferred by scope because this milestone is limited to `application/json`.
+
+Notes on proof boundaries:
+
+- The package-owned spec suite also verifies a few stricter package invariants
+  that go beyond explicit upstream MUST-level wording for the pinned snapshot.
+- These stricter checks currently include: omitting SSE `id` fields entirely,
+  monotonically increasing built-in `sequence_number` values, and package
+  policy choices for missing or unusable `previous_response_id` records and
+  unmet required tool-call execution.

--- a/packages/openresponses-adapter/contracts/openresponses/REQUIREMENT-MATRIX.md
+++ b/packages/openresponses-adapter/contracts/openresponses/REQUIREMENT-MATRIX.md
@@ -31,13 +31,9 @@ Scope notes:
 | OR-STREAM-007 | specification + reference/openapi | Post-start failures emit an `error` event and resolve through terminal `response.failed` semantics | spec_conformance | `post-start-failure` | covered |
 | OR-STREAM-008 | reference/openapi | Incomplete executions emit `response.incomplete` and terminal incomplete state | spec_conformance | `incomplete-terminal` | covered |
 | OR-STREAM-009 | reference/openapi | Reasoning summary event families are emitted when reasoning summaries are present | spec_conformance | `reasoning-summary-coverage` | covered |
-| OR-CONT-001 | specification | Continuation semantics are keyed by `previous_response_id` and replay prior input before prior output before new input | official_runner | `multi-turn` plus existing continuation regressions | partial |
-| OR-TOOLS-001 | specification + reference/openapi | Tool-calling paths surface contract-valid function-call behavior | official_runner | `tool-calling` | partial |
+| OR-CONT-001 | specification | Continuation semantics are keyed by `previous_response_id` and replay prior input before prior output before new input | spec_conformance | `continuation-coverage` | covered |
+| OR-TOOLS-001 | specification + reference/openapi | Tool-calling paths surface contract-valid function-call behavior and tool-governance semantics | spec_conformance | `tool-governance-coverage` | covered |
 
-`partial` rows are intentionally called out because the current proof only
-covers a narrower slice of the normative contract than the row title implies.
-For `OR-CONT-001` and `OR-TOOLS-001`, the official runner gives useful
-baseline coverage but does not fully prove the broader continuation and
-tool-governance contract on its own. Those rows are the next candidates for
-black-box expansion if the package needs a stricter release claim than the
-current JSON-surface milestone.
+No in-scope JSON-surface requirement rows are intentionally left `partial`.
+The only remaining non-covered row is `OR-HTTP-004`, which is explicitly
+deferred by scope because this milestone is limited to `application/json`.

--- a/packages/openresponses-adapter/contracts/openresponses/REQUIREMENT-MATRIX.md
+++ b/packages/openresponses-adapter/contracts/openresponses/REQUIREMENT-MATRIX.md
@@ -1,0 +1,41 @@
+# OpenResponses JSON-Surface Requirement Matrix
+
+This matrix records the pinned OpenResponses requirements that this package
+claims to satisfy for the JSON request surface. It separates the official
+runner baseline from the package-owned spec-conformance suite so release claims
+do not overfit the six upstream acceptance scenarios.
+
+Scope notes:
+
+- Contract snapshot: `2.3.0+0e3605e36180`
+- In-scope transport: `application/json`
+- Deferred by explicit scope: `application/x-www-form-urlencoded`
+- Proof types:
+  - `official_runner`: vendored upstream acceptance suite
+  - `spec_conformance`: package-owned black-box HTTP proof
+  - `shared`: covered by both
+
+| ID | Source | Requirement | Proof Type | Proof Ref | Status |
+| --- | --- | --- | --- | --- | --- |
+| OR-HTTP-001 | specification | Non-streaming responses return `application/json` | shared | `basic-response`, `response-resource-complete` | covered |
+| OR-HTTP-002 | specification | Streaming responses return `text/event-stream` | shared | `streaming-response`, `sse-framing-and-ordering` | covered |
+| OR-HTTP-003 | specification | JSON is the in-scope request body encoding for this milestone | spec_conformance | `response-resource-complete`, `sse-framing-and-ordering` | covered |
+| OR-HTTP-004 | reference/openapi | `application/x-www-form-urlencoded` is published upstream but deferred from this milestone by explicit scope | deferred_by_scope | user scope decision on 2026-03-26 | deferred |
+| OR-RESP-001 | reference/openapi | Terminal JSON responses contain the full `ResponseResource` shape, including nullable/defaulted fields | shared | `basic-response`, `response-resource-complete` | covered |
+| OR-STREAM-001 | specification | SSE `event` must match body `type` | spec_conformance | `sse-framing-and-ordering` | covered |
+| OR-STREAM-002 | specification | SSE frames must not use the `id` field | spec_conformance | `sse-framing-and-ordering` | covered |
+| OR-STREAM-003 | specification | Streaming terminates with literal `[DONE]` after the terminal event | shared | `streaming-response`, `sse-framing-and-ordering` | covered |
+| OR-STREAM-004 | reference/openapi | Terminal stream events carry the full `ResponseResource` | shared | `streaming-response`, `sse-framing-and-ordering` | covered |
+| OR-STREAM-005 | specification | Sequence numbers are monotonic across a response stream | spec_conformance | `sse-framing-and-ordering` | covered |
+| OR-STREAM-006 | specification | Stream lifecycle ordering begins `response.created -> response.queued -> response.in_progress` | spec_conformance | `sse-framing-and-ordering` | covered |
+| OR-STREAM-007 | specification + reference/openapi | Post-start failures emit an `error` event and resolve through terminal `response.failed` semantics | spec_conformance | `post-start-failure` | covered |
+| OR-STREAM-008 | reference/openapi | Incomplete executions emit `response.incomplete` and terminal incomplete state | spec_conformance | `incomplete-terminal` | covered |
+| OR-STREAM-009 | reference/openapi | Reasoning summary event families are emitted when reasoning summaries are present | spec_conformance | `reasoning-summary-coverage` | covered |
+| OR-CONT-001 | specification | Continuation semantics are keyed by `previous_response_id` and replay prior input before prior output before new input | official_runner | `multi-turn` plus existing continuation regressions | partial |
+| OR-TOOLS-001 | specification + reference/openapi | Tool-calling paths surface contract-valid function-call behavior | official_runner | `tool-calling` | partial |
+
+`partial` rows are intentionally called out because the official runner gives
+useful baseline coverage but does not fully prove the broader normative
+continuation and tool-governance contract on its own. Those rows should be the
+next candidates for black-box expansion if the package needs a stricter release
+claim than the current JSON-surface milestone.

--- a/packages/openresponses-adapter/package.json
+++ b/packages/openresponses-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@skroyc/openresponses-adapter",
   "version": "0.1.0",
-  "description": "Open Responses adapter for LangChain agents with full pinned-snapshot compliance, truthful SSE streaming, and official runner release gating",
+  "description": "Open Responses adapter for LangChain agents with pinned-snapshot JSON-surface compliance, truthful SSE streaming, and official runner + spec-conformance release gating",
   "keywords": [
     "langchain",
     "open-responses",
@@ -51,6 +51,8 @@
     "test:compliance": "bun run test:compliance:local",
     "test:compliance:local": "bun test tests/compliance/local-regression.spec.ts",
     "test:compliance:official": "bun ./scripts/run-official-compliance.ts",
+    "test:compliance:spec": "bun ./scripts/run-spec-conformance.ts",
+    "test:compliance:full": "bun run test:compliance:official && bun run test:compliance:spec",
     "lint": "bunx --bun @biomejs/biome check .",
     "format": "bunx --bun @biomejs/biome format --write .",
     "typecheck": "tsc --noEmit",

--- a/packages/openresponses-adapter/scripts/run-spec-conformance.ts
+++ b/packages/openresponses-adapter/scripts/run-spec-conformance.ts
@@ -3,8 +3,15 @@
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { parseSSEStream } from "../contracts/openresponses/compliance-runner/sse-parser.ts";
-import type { OpenResponsesCompatibleAgent } from "../src/core/types.ts";
-import { createFakeAgent } from "../src/testing/fake-agent.ts";
+import type {
+  OpenResponsesCompatibleAgent,
+  PreviousResponseStore,
+} from "../src/core/types.ts";
+import {
+  createFakeAgent,
+  createInMemoryPreviousResponseStore,
+} from "../src/testing/index.ts";
+import { createPriorRecord } from "../tests/helpers/records.ts";
 import {
   createCallbackDrivenAgent,
   simulateIncompleteStream,
@@ -43,12 +50,14 @@ const buildPackage = async (): Promise<void> => {
 
 const startFixtureServer = async (params: {
   agent: OpenResponsesCompatibleAgent;
+  previousResponseStore?: PreviousResponseStore;
   timeoutBudgets?: {
     agentExecutionMs?: number;
     previousResponseLoadMs?: number;
     previousResponseSaveMs?: number;
     requestValidationMs?: number;
   };
+  toolPolicySupport?: "metadata-only" | "middleware";
 }) => {
   const { buildOpenResponsesApp } = (await import(
     distServerPath
@@ -56,7 +65,13 @@ const startFixtureServer = async (params: {
 
   const app = await buildOpenResponsesApp({
     agent: params.agent,
+    ...(params.previousResponseStore
+      ? { previousResponseStore: params.previousResponseStore }
+      : {}),
     ...(params.timeoutBudgets ? { timeoutBudgets: params.timeoutBudgets } : {}),
+    ...(params.toolPolicySupport
+      ? { toolPolicySupport: params.toolPolicySupport }
+      : {}),
   });
 
   const server = Bun.serve({
@@ -377,6 +392,319 @@ const runReasoningSummaryCoverage = async (): Promise<void> => {
   }
 };
 
+const runContinuationCoverage = async (): Promise<void> => {
+  const previousResponseStore = createInMemoryPreviousResponseStore();
+  await previousResponseStore.save(createPriorRecord());
+
+  const agent = createFakeAgent({
+    responses: [{ type: "ai", id: "ai-next", content: "Follow-up answer" }],
+  });
+
+  const server = await startFixtureServer({
+    agent,
+    previousResponseStore,
+  });
+
+  try {
+    const continuedResponse = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: createJsonHeaders(),
+      body: JSON.stringify({
+        model: "gpt-4.1-mini",
+        previous_response_id: "resp-prev",
+        input: [
+          {
+            type: "message",
+            role: "user",
+            content: "Explain why it is funny.",
+          },
+        ],
+        metadata: {},
+        tools: [],
+        parallel_tool_calls: true,
+        stream: false,
+      }),
+    });
+
+    assertCondition(
+      continuedResponse.status === 200,
+      "continuation-coverage: expected 200 for known previous_response_id"
+    );
+
+    const payload = (await continuedResponse.json()) as {
+      previous_response_id: string | null;
+    };
+    assertCondition(
+      payload.previous_response_id === "resp-prev",
+      "continuation-coverage: response must echo previous_response_id"
+    );
+
+    assertCondition(
+      JSON.stringify(agent.__getLastInvokeInput()?.messages) ===
+        JSON.stringify([
+          {
+            type: "system",
+            role: "system",
+            content: [{ type: "input_text", text: "Be terse." }],
+          },
+          {
+            type: "human",
+            role: "user",
+            content: "Tell me a joke",
+          },
+          {
+            type: "ai",
+            role: "assistant",
+            content: [
+              {
+                type: "output_text",
+                text: "Why did the test cross the road?",
+                annotations: [],
+                logprobs: [],
+              },
+            ],
+          },
+          {
+            type: "human",
+            role: "user",
+            content: "Explain why it is funny.",
+          },
+        ]),
+      "continuation-coverage: expected prior input -> prior output -> new input replay order"
+    );
+
+    const missingRecordResponse = await fetch(
+      `${server.baseUrl}/v1/responses`,
+      {
+        method: "POST",
+        headers: createJsonHeaders(),
+        body: JSON.stringify({
+          model: "gpt-4.1-mini",
+          previous_response_id: "missing",
+          input: "Next",
+        }),
+      }
+    );
+    assertCondition(
+      missingRecordResponse.status === 404,
+      "continuation-coverage: missing previous response must return 404"
+    );
+
+    const malformedStore: PreviousResponseStore = {
+      load: async () => ({
+        ...createPriorRecord(),
+        response: {
+          ...createPriorRecord().response,
+          status: "queued" as const,
+        },
+      }),
+      save: async () => {
+        // Intentionally unused for malformed-record verification.
+      },
+    };
+
+    const malformedServer = await startFixtureServer({
+      agent: createFakeAgent(),
+      previousResponseStore: malformedStore,
+    });
+
+    try {
+      const malformedResponse = await fetch(
+        `${malformedServer.baseUrl}/v1/responses`,
+        {
+          method: "POST",
+          headers: createJsonHeaders(),
+          body: JSON.stringify({
+            model: "gpt-4.1-mini",
+            previous_response_id: "resp-prev",
+            input: "Next",
+          }),
+        }
+      );
+      assertCondition(
+        malformedResponse.status === 409,
+        "continuation-coverage: unusable previous response must return 409"
+      );
+    } finally {
+      await malformedServer.stop();
+    }
+  } finally {
+    await server.stop();
+  }
+};
+
+const runToolGovernanceCoverage = async (): Promise<void> => {
+  const middlewareRequiredServer = await startFixtureServer({
+    agent: createFakeAgent(),
+  });
+
+  try {
+    const restrictiveResponse = await fetch(
+      `${middlewareRequiredServer.baseUrl}/v1/responses`,
+      {
+        method: "POST",
+        headers: createJsonHeaders(),
+        body: JSON.stringify({
+          model: "gpt-4.1-mini",
+          input: "Hello",
+          metadata: {},
+          tools: [
+            {
+              type: "function",
+              name: "lookup_fact",
+              description: "Lookup a fact",
+              parameters: { type: "object" },
+              strict: true,
+            },
+          ],
+          tool_choice: {
+            type: "function",
+            name: "lookup_fact",
+          },
+          parallel_tool_calls: true,
+          stream: false,
+        }),
+      }
+    );
+
+    assertCondition(
+      restrictiveResponse.status === 400,
+      "tool-governance: restrictive tool policy without middleware support must return 400"
+    );
+  } finally {
+    await middlewareRequiredServer.stop();
+  }
+
+  const lookupFactTool = {
+    type: "function" as const,
+    name: "lookup_fact",
+    description: "Lookup a fact",
+    parameters: { type: "object" },
+    strict: true,
+  };
+
+  const allowedToolsAgent = createFakeAgent({
+    responses: [
+      [
+        {
+          type: "ai",
+          id: "ai-call",
+          content: "",
+          tool_calls: [
+            {
+              id: "tool-call-1",
+              name: "lookup_fact",
+              args: { topic: "road" },
+            },
+          ],
+        },
+        {
+          type: "tool",
+          id: "tool-result-1",
+          content: '{"result":"because tests do that"}',
+          tool_call_id: "tool-call-1",
+        },
+        {
+          type: "ai",
+          id: "ai-final",
+          content: "Done.",
+        },
+      ],
+    ],
+  });
+
+  const toolServer = await startFixtureServer({
+    agent: allowedToolsAgent,
+    toolPolicySupport: "middleware",
+  });
+
+  try {
+    const allowedToolsResponse = await fetch(
+      `${toolServer.baseUrl}/v1/responses`,
+      {
+        method: "POST",
+        headers: createJsonHeaders(),
+        body: JSON.stringify({
+          model: "gpt-4.1-mini",
+          input: "Hello",
+          metadata: {},
+          tools: [lookupFactTool],
+          tool_choice: {
+            type: "allowed_tools",
+            tools: [{ type: "function", name: "lookup_fact" }],
+            mode: "auto",
+          },
+          parallel_tool_calls: true,
+          stream: false,
+        }),
+      }
+    );
+
+    assertCondition(
+      allowedToolsResponse.status === 200,
+      "tool-governance: allowed_tools request with middleware support must succeed"
+    );
+
+    const lastConfig = allowedToolsAgent.__getLastInvokeConfig() as {
+      configurable?: Record<string, unknown>;
+    } | null;
+    const serializedPolicy = lastConfig?.configurable
+      ?.openresponses_tool_policy as
+      | {
+          allowedToolNames?: string[];
+          parallelToolCalls?: boolean;
+          toolChoice?: Record<string, unknown>;
+        }
+      | undefined;
+
+    assertCondition(
+      JSON.stringify(serializedPolicy?.allowedToolNames) ===
+        JSON.stringify(["lookup_fact"]),
+      "tool-governance: expected allowed tool names to be serialized into runtime config"
+    );
+  } finally {
+    await toolServer.stop();
+  }
+
+  const requiredToolServer = await startFixtureServer({
+    agent: createFakeAgent({
+      responses: [
+        { type: "ai", id: "ai-1", content: "No tool call happened." },
+      ],
+    }),
+    toolPolicySupport: "middleware",
+  });
+
+  try {
+    const requiredToolFailureResponse = await fetch(
+      `${requiredToolServer.baseUrl}/v1/responses`,
+      {
+        method: "POST",
+        headers: createJsonHeaders(),
+        body: JSON.stringify({
+          model: "gpt-4.1-mini",
+          input: "Hello",
+          metadata: {},
+          tools: [lookupFactTool],
+          tool_choice: {
+            type: "function",
+            name: "lookup_fact",
+          },
+          parallel_tool_calls: true,
+          stream: false,
+        }),
+      }
+    );
+
+    assertCondition(
+      requiredToolFailureResponse.status === 500,
+      "tool-governance: unmet required tool semantics must surface as runtime failure"
+    );
+  } finally {
+    await requiredToolServer.stop();
+  }
+};
+
 const checks = [
   {
     id: "response-resource-complete",
@@ -397,6 +725,14 @@ const checks = [
   {
     id: "reasoning-summary-coverage",
     run: runReasoningSummaryCoverage,
+  },
+  {
+    id: "continuation-coverage",
+    run: runContinuationCoverage,
+  },
+  {
+    id: "tool-governance-coverage",
+    run: runToolGovernanceCoverage,
   },
 ] as const;
 

--- a/packages/openresponses-adapter/scripts/run-spec-conformance.ts
+++ b/packages/openresponses-adapter/scripts/run-spec-conformance.ts
@@ -1,0 +1,436 @@
+#!/usr/bin/env bun
+
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { parseSSEStream } from "../contracts/openresponses/compliance-runner/sse-parser.ts";
+import type { OpenResponsesCompatibleAgent } from "../src/core/types.ts";
+import { createFakeAgent } from "../src/testing/fake-agent.ts";
+import {
+  createCallbackDrivenAgent,
+  simulateIncompleteStream,
+  simulateReasoningSummaryStream,
+  simulateTextStream,
+} from "../tests/helpers/streaming-fixtures.ts";
+
+declare const Bun: typeof import("bun");
+
+const packageRoot = resolve(import.meta.dir, "..");
+const distServerPath = pathToFileURL(
+  resolve(packageRoot, "dist/server.js")
+).href;
+
+function assertCondition(
+  condition: unknown,
+  message: string
+): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const buildPackage = async (): Promise<void> => {
+  const proc = Bun.spawn({
+    cmd: ["bun", "run", "build"],
+    cwd: packageRoot,
+    stderr: "inherit",
+    stdout: "inherit",
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    process.exit(exitCode);
+  }
+};
+
+const startFixtureServer = async (params: {
+  agent: OpenResponsesCompatibleAgent;
+  timeoutBudgets?: {
+    agentExecutionMs?: number;
+    previousResponseLoadMs?: number;
+    previousResponseSaveMs?: number;
+    requestValidationMs?: number;
+  };
+}) => {
+  const { buildOpenResponsesApp } = (await import(
+    distServerPath
+  )) as typeof import("../src/server/index.ts");
+
+  const app = await buildOpenResponsesApp({
+    agent: params.agent,
+    ...(params.timeoutBudgets ? { timeoutBudgets: params.timeoutBudgets } : {}),
+  });
+
+  const server = Bun.serve({
+    fetch(request) {
+      return app.fetch(request);
+    },
+    hostname: "127.0.0.1",
+    port: 0,
+  });
+
+  return {
+    baseUrl: `http://127.0.0.1:${server.port}`,
+    async stop() {
+      await server.stop(true);
+    },
+  };
+};
+
+const createJsonHeaders = () => ({
+  "content-type": "application/json",
+});
+
+const createBaseRequest = () => ({
+  model: "test-model",
+  input: "Hello",
+  tools: [],
+  parallel_tool_calls: true,
+  stream: true,
+  metadata: {},
+});
+
+const collectRawSSE = async (
+  baseUrl: string,
+  body: Record<string, unknown>
+) => {
+  const response = await fetch(`${baseUrl}/v1/responses`, {
+    method: "POST",
+    headers: createJsonHeaders(),
+    body: JSON.stringify(body),
+  });
+
+  const raw = await response.text();
+  return {
+    response,
+    raw,
+  };
+};
+
+const runResponseResourceCompleteness = async (): Promise<void> => {
+  const server = await startFixtureServer({ agent: createFakeAgent() });
+
+  try {
+    const response = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: createJsonHeaders(),
+      body: JSON.stringify({
+        ...createBaseRequest(),
+        stream: false,
+        instructions: "Be terse.",
+        text: { format: { type: "text" }, verbosity: "medium" },
+        reasoning: { effort: "medium", summary: "auto" },
+        temperature: 0.3,
+        top_p: 0.9,
+        presence_penalty: 0,
+        frequency_penalty: 0,
+        top_logprobs: 0,
+        max_output_tokens: 128,
+        max_tool_calls: 2,
+        store: false,
+        background: false,
+        service_tier: "default",
+        safety_identifier: "safe-1",
+        prompt_cache_key: "cache-1",
+      }),
+    });
+
+    assertCondition(
+      response.status === 200,
+      "response-resource-complete: expected 200"
+    );
+    assertCondition(
+      response.headers.get("content-type")?.includes("application/json"),
+      "response-resource-complete: expected application/json"
+    );
+
+    const payload = (await response.json()) as Record<string, unknown>;
+    for (const field of [
+      "id",
+      "object",
+      "created_at",
+      "completed_at",
+      "status",
+      "incomplete_details",
+      "model",
+      "previous_response_id",
+      "instructions",
+      "output",
+      "error",
+      "tools",
+      "tool_choice",
+      "truncation",
+      "parallel_tool_calls",
+      "text",
+      "top_p",
+      "presence_penalty",
+      "frequency_penalty",
+      "top_logprobs",
+      "temperature",
+      "reasoning",
+      "usage",
+      "max_output_tokens",
+      "max_tool_calls",
+      "store",
+      "background",
+      "service_tier",
+      "metadata",
+      "safety_identifier",
+      "prompt_cache_key",
+    ]) {
+      assertCondition(
+        field in payload,
+        `response-resource-complete: missing ${field}`
+      );
+    }
+  } finally {
+    await server.stop();
+  }
+};
+
+const runSseFramingAndOrdering = async (): Promise<void> => {
+  const server = await startFixtureServer({
+    agent: createCallbackDrivenAgent({ onStream: simulateTextStream }),
+  });
+
+  try {
+    const parsedResponse = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: createJsonHeaders(),
+      body: JSON.stringify(createBaseRequest()),
+    });
+    assertCondition(parsedResponse.status === 200, "sse-framing: expected 200");
+    assertCondition(
+      parsedResponse.headers.get("content-type")?.includes("text/event-stream"),
+      "sse-framing: expected text/event-stream"
+    );
+
+    const parsed = await parseSSEStream(parsedResponse);
+    assertCondition(
+      parsed.errors.length === 0,
+      `sse-framing: ${parsed.errors.join("; ")}`
+    );
+
+    const types = parsed.events.map((event) => event.event);
+    assertCondition(
+      JSON.stringify(types.slice(0, 3)) ===
+        JSON.stringify([
+          "response.created",
+          "response.queued",
+          "response.in_progress",
+        ]),
+      "sse-framing: expected created -> queued -> in_progress ordering"
+    );
+
+    for (const event of parsed.events) {
+      const data = event.data as { type?: string; sequence_number?: number };
+      assertCondition(
+        event.event === data.type,
+        `sse-framing: event header/body mismatch for ${event.event}`
+      );
+    }
+
+    const sequenceNumbers = parsed.events.map((event) => {
+      return (event.data as { sequence_number: number }).sequence_number;
+    });
+    for (let index = 0; index < sequenceNumbers.length; index++) {
+      assertCondition(
+        sequenceNumbers[index] === index + 1,
+        "sse-framing: expected monotonic sequence_number values"
+      );
+    }
+
+    const rawResponse = await collectRawSSE(
+      server.baseUrl,
+      createBaseRequest()
+    );
+    assertCondition(
+      !rawResponse.raw.includes("\nid:"),
+      "sse-framing: SSE stream must not emit id fields"
+    );
+    assertCondition(
+      rawResponse.raw.trimEnd().endsWith("data: [DONE]"),
+      "sse-framing: stream must terminate with literal [DONE]"
+    );
+  } finally {
+    await server.stop();
+  }
+};
+
+const runPostStartFailure = async (): Promise<void> => {
+  const server = await startFixtureServer({
+    agent: createFakeAgent({
+      streamChunks: [{ type: "chunk", content: "late" }],
+      delay: 30,
+    }),
+    timeoutBudgets: { agentExecutionMs: 10 },
+  });
+
+  try {
+    const response = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: createJsonHeaders(),
+      body: JSON.stringify(createBaseRequest()),
+    });
+
+    const parsed = await parseSSEStream(response);
+    assertCondition(
+      parsed.errors.length === 0,
+      `post-start-failure: ${parsed.errors.join("; ")}`
+    );
+
+    const types = parsed.events.map((event) => event.event);
+    const errorIndex = types.indexOf("error");
+    const failedIndex = types.indexOf("response.failed");
+    assertCondition(errorIndex >= 0, "post-start-failure: missing error event");
+    assertCondition(
+      failedIndex > errorIndex,
+      "post-start-failure: response.failed must follow error"
+    );
+    assertCondition(
+      parsed.finalResponse?.status === "failed",
+      "post-start-failure: final response must be failed"
+    );
+  } finally {
+    await server.stop();
+  }
+};
+
+const runIncompleteTerminal = async (): Promise<void> => {
+  const server = await startFixtureServer({
+    agent: createCallbackDrivenAgent({ onStream: simulateIncompleteStream }),
+  });
+
+  try {
+    const response = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: createJsonHeaders(),
+      body: JSON.stringify(createBaseRequest()),
+    });
+
+    const parsed = await parseSSEStream(response);
+    assertCondition(
+      parsed.errors.length === 0,
+      `incomplete-stream: ${parsed.errors.join("; ")}`
+    );
+    const incompleteEvent = parsed.events.find((event) => {
+      return event.event === "response.incomplete";
+    });
+    assertCondition(
+      incompleteEvent,
+      "incomplete-stream: missing response.incomplete"
+    );
+    assertCondition(
+      parsed.finalResponse?.status === "incomplete",
+      "incomplete-stream: final response must be incomplete"
+    );
+  } finally {
+    await server.stop();
+  }
+};
+
+const runReasoningSummaryCoverage = async (): Promise<void> => {
+  const server = await startFixtureServer({
+    agent: createCallbackDrivenAgent({
+      onStream: simulateReasoningSummaryStream,
+    }),
+  });
+
+  try {
+    const response = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: createJsonHeaders(),
+      body: JSON.stringify(createBaseRequest()),
+    });
+
+    const parsed = await parseSSEStream(response);
+    assertCondition(
+      parsed.errors.length === 0,
+      `reasoning-summary: ${parsed.errors.join("; ")}`
+    );
+    const types = parsed.events.map((event) => event.event);
+    for (const type of [
+      "response.reasoning_summary_part.added",
+      "response.reasoning_summary_text.delta",
+      "response.reasoning_summary_text.done",
+      "response.reasoning_summary_part.done",
+    ]) {
+      assertCondition(
+        types.includes(type),
+        `reasoning-summary: missing ${type}`
+      );
+    }
+
+    const reasoningItem = parsed.finalResponse?.output.find((item) => {
+      return (
+        typeof item === "object" && item !== null && item.type === "reasoning"
+      );
+    }) as { summary?: Array<{ type: string; text: string }> } | undefined;
+    assertCondition(
+      reasoningItem,
+      "reasoning-summary: missing reasoning output item"
+    );
+    assertCondition(
+      reasoningItem.summary?.[0]?.text === "Short answer summary",
+      "reasoning-summary: final reasoning item must preserve summary text"
+    );
+  } finally {
+    await server.stop();
+  }
+};
+
+const checks = [
+  {
+    id: "response-resource-complete",
+    run: runResponseResourceCompleteness,
+  },
+  {
+    id: "sse-framing-and-ordering",
+    run: runSseFramingAndOrdering,
+  },
+  {
+    id: "post-start-failure",
+    run: runPostStartFailure,
+  },
+  {
+    id: "incomplete-terminal",
+    run: runIncompleteTerminal,
+  },
+  {
+    id: "reasoning-summary-coverage",
+    run: runReasoningSummaryCoverage,
+  },
+] as const;
+
+await buildPackage();
+
+const results: Array<{
+  id: string;
+  status: "passed" | "failed";
+  error?: string;
+}> = [];
+
+for (const check of checks) {
+  try {
+    await check.run();
+    results.push({ id: check.id, status: "passed" });
+  } catch (error) {
+    results.push({
+      id: check.id,
+      status: "failed",
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+const failed = results.filter((result) => result.status === "failed");
+process.stdout.write(
+  `Spec conformance summary: ${results.length - failed.length} passed, ${failed.length} failed, ${results.length} total\n`
+);
+for (const result of results) {
+  process.stdout.write(
+    `${result.id}: ${result.status}${result.error ? ` - ${result.error}` : ""}\n`
+  );
+}
+
+if (failed.length > 0) {
+  process.exit(1);
+}

--- a/packages/openresponses-adapter/src/server/adapter.ts
+++ b/packages/openresponses-adapter/src/server/adapter.ts
@@ -540,9 +540,15 @@ export function createOpenResponsesAdapter(
           completedAt: lifecycle.getCompletedAt(),
           status,
           output: accumulator.snapshot().filter((item) => {
-            return !(
-              item.type === "function_call" && replayedCallIds.has(item.call_id)
-            );
+            if (item.type === "function_call") {
+              return !replayedCallIds.has(item.call_id);
+            }
+
+            if (item.type === "function_call_output") {
+              return !replayedCallIds.has(item.call_id);
+            }
+
+            return true;
           }),
           error: lifecycle.getError(),
         });

--- a/packages/openresponses-adapter/src/server/event-serializer.ts
+++ b/packages/openresponses-adapter/src/server/event-serializer.ts
@@ -109,6 +109,34 @@ const errorToErrorObject = (error: unknown) => {
   return internalErrorToPublicError(internal);
 };
 
+const emitErrorEvent = (
+  context: SerializerContext,
+  error: NonNullable<OpenResponsesResponse["error"]>
+): OpenResponsesEvent => {
+  return {
+    type: "error",
+    sequence_number: context.sequence.next(),
+    error: {
+      type: error.type,
+      code: error.code,
+      message: error.message,
+      param: error.param ?? null,
+    },
+  } as OpenResponsesEvent;
+};
+
+const emitFailedTerminalEvents = (
+  context: SerializerContext,
+  error: NonNullable<OpenResponsesResponse["error"]>
+): OpenResponsesEvent[] => {
+  return [
+    emitErrorEvent(context, error),
+    emitLifecycleEvent("response.failed", context, "failed", {
+      error,
+    }),
+  ];
+};
+
 const buildResponseSnapshot = (
   context: SerializerContext,
   status?: OpenResponsesResponse["status"],
@@ -472,7 +500,7 @@ const serializeReasoningCompleted = (
     );
   }
 
-  return [
+  const events: OpenResponsesEvent[] = [
     {
       type: "response.reasoning.done",
       sequence_number: context.sequence.next(),
@@ -489,13 +517,55 @@ const serializeReasoningCompleted = (
       content_index: 0,
       part: reasoningText,
     },
-    {
-      type: "response.output_item.done",
-      sequence_number: context.sequence.next(),
-      output_index: outputIndex,
-      item: finalizedItem,
-    },
   ];
+
+  for (const [summaryIndex, summaryPart] of finalizedItem.summary.entries()) {
+    const summaryText =
+      summaryPart.type === "summary_text" ? summaryPart.text : "";
+    events.push(
+      {
+        type: "response.reasoning_summary_part.added",
+        sequence_number: context.sequence.next(),
+        item_id: event.itemId,
+        output_index: outputIndex,
+        summary_index: summaryIndex,
+        part: summaryPart,
+      },
+      {
+        type: "response.reasoning_summary_text.delta",
+        sequence_number: context.sequence.next(),
+        item_id: event.itemId,
+        output_index: outputIndex,
+        summary_index: summaryIndex,
+        delta: summaryText,
+      },
+      {
+        type: "response.reasoning_summary_text.done",
+        sequence_number: context.sequence.next(),
+        item_id: event.itemId,
+        output_index: outputIndex,
+        summary_index: summaryIndex,
+        text: summaryText,
+      },
+      {
+        type: "response.reasoning_summary_part.done",
+        sequence_number: context.sequence.next(),
+        item_id: event.itemId,
+        output_index: outputIndex,
+        summary_index: summaryIndex,
+        part: summaryPart,
+      }
+    );
+  }
+
+  events.push({
+    type: "response.output_item.done",
+    sequence_number: context.sequence.next(),
+    output_index: outputIndex,
+    item: finalizedItem,
+  });
+
+  return events;
 };
 
 const serializeAnnotationAdded = (
@@ -661,11 +731,7 @@ const serializeRunFailed = (
     context.lifecycle.start();
   }
   context.lifecycle.fail(errorObject);
-  return [
-    emitLifecycleEvent("response.failed", context, "failed", {
-      error: errorObject,
-    }),
-  ];
+  return emitFailedTerminalEvents(context, errorObject);
 };
 
 const serializeRunIncomplete = (
@@ -781,11 +847,9 @@ export async function* createEventSerializer(params: {
     }
     if (params.lifecycle.getStatus() === "in_progress") {
       params.lifecycle.fail(errorObject);
-      yield validateOutgoingEvent(
-        emitLifecycleEvent("response.failed", context, "failed", {
-          error: errorObject,
-        })
-      );
+      for (const event of emitFailedTerminalEvents(context, errorObject)) {
+        yield validateOutgoingEvent(event);
+      }
     }
   }
 

--- a/packages/openresponses-adapter/src/server/event-serializer.ts
+++ b/packages/openresponses-adapter/src/server/event-serializer.ts
@@ -137,6 +137,13 @@ const emitFailedTerminalEvents = (
   ];
 };
 
+const ensureTerminalInProgressPrefix = (
+  context: SerializerContext
+): OpenResponsesEvent[] => {
+  const inProgressEvent = ensureInProgressEvent(context);
+  return inProgressEvent ? [inProgressEvent] : [];
+};
+
 const buildResponseSnapshot = (
   context: SerializerContext,
   status?: OpenResponsesResponse["status"],
@@ -710,11 +717,10 @@ const serializeRunCompleted = (
     return [];
   }
 
-  if (context.lifecycle.getStatus() === "queued") {
-    context.lifecycle.start();
-  }
+  const events = ensureTerminalInProgressPrefix(context);
   context.lifecycle.complete();
-  return [emitLifecycleEvent("response.completed", context, "completed")];
+  events.push(emitLifecycleEvent("response.completed", context, "completed"));
+  return events;
 };
 
 const serializeRunFailed = (
@@ -727,11 +733,10 @@ const serializeRunFailed = (
 
   const errorObject = errorToErrorObject(event.error);
   context.accumulator.finalizeOpenItemsAsIncomplete();
-  if (context.lifecycle.getStatus() === "queued") {
-    context.lifecycle.start();
-  }
+  const events = ensureTerminalInProgressPrefix(context);
   context.lifecycle.fail(errorObject);
-  return emitFailedTerminalEvents(context, errorObject);
+  events.push(...emitFailedTerminalEvents(context, errorObject));
+  return events;
 };
 
 const serializeRunIncomplete = (
@@ -743,17 +748,16 @@ const serializeRunIncomplete = (
   }
 
   context.accumulator.finalizeOpenItemsAsIncomplete();
-  if (context.lifecycle.getStatus() === "queued") {
-    context.lifecycle.start();
-  }
+  const events = ensureTerminalInProgressPrefix(context);
   context.lifecycle.incomplete();
-  return [
+  events.push(
     emitLifecycleEvent("response.incomplete", context, "incomplete", {
       incompleteDetails: {
         reason: event.reason ?? "stream_ended_before_terminal_state",
       },
-    }),
-  ];
+    })
+  );
+  return events;
 };
 
 export const serializeInternalEvent = (
@@ -842,8 +846,8 @@ export async function* createEventSerializer(params: {
   } catch (error) {
     const errorObject = errorToErrorObject(error);
     context.accumulator.finalizeOpenItemsAsIncomplete();
-    if (params.lifecycle.getStatus() === "queued") {
-      params.lifecycle.start();
+    for (const event of ensureTerminalInProgressPrefix(context)) {
+      yield validateOutgoingEvent(event);
     }
     if (params.lifecycle.getStatus() === "in_progress") {
       params.lifecycle.fail(errorObject);
@@ -856,8 +860,10 @@ export async function* createEventSerializer(params: {
   const status = params.lifecycle.getStatus();
   if (status === "queued" || status === "in_progress") {
     context.accumulator.finalizeOpenItemsAsIncomplete();
-    if (status === "queued") {
-      params.lifecycle.start();
+    if (params.lifecycle.getStatus() === "queued") {
+      for (const event of ensureTerminalInProgressPrefix(context)) {
+        yield validateOutgoingEvent(event);
+      }
     }
     params.lifecycle.incomplete();
     yield validateOutgoingEvent(

--- a/packages/openresponses-adapter/src/server/previous-response.ts
+++ b/packages/openresponses-adapter/src/server/previous-response.ts
@@ -20,7 +20,10 @@ import type {
   OutputTextPart,
   ToolChoice,
 } from "@/core/schemas.js";
-import { OpenResponsesRequestSchema } from "@/core/schemas.js";
+import {
+  OpenResponsesRequestSchema,
+  OutputItemSchema,
+} from "@/core/schemas.js";
 import { getEffectiveToolChoiceMode } from "@/core/tool-policy.js";
 import type {
   LangChainMessageLike,
@@ -892,6 +895,51 @@ const inputItemToMessage = (item: InputItem): LangChainMessageLike => {
   };
 };
 
+const reasoningSummaryPartToText = (part: unknown): string => {
+  if (!isRecord(part)) {
+    return "";
+  }
+
+  if (typeof part.text === "string") {
+    return part.text;
+  }
+
+  if (typeof part.refusal === "string") {
+    return part.refusal;
+  }
+
+  return "";
+};
+
+const inputItemToMessages = (item: InputItem): LangChainMessageLike[] => {
+  if (item.type === "item_reference") {
+    // The adapter preserves item references in the request snapshot, but the
+    // LangChain runtime does not expose an equivalent message primitive.
+    return [];
+  }
+
+  if (item.type === "reasoning") {
+    const content = item.summary
+      .map(reasoningSummaryPartToText)
+      .filter((part) => part.length > 0)
+      .join(" ");
+
+    if (content.length === 0) {
+      return [];
+    }
+
+    return [
+      {
+        type: "ai",
+        role: "assistant",
+        content,
+      },
+    ];
+  }
+
+  return [inputItemToMessage(item)];
+};
+
 const normalizeToolPolicy = (
   request: ResolvedOpenResponsesRequest
 ): NormalizedToolPolicy => {
@@ -1095,6 +1143,14 @@ const normalizeStoredResponseOutput = (
   const normalizedOutput: OutputItem[] = [];
 
   for (const candidate of output) {
+    const currentShapeResult = OutputItemSchema.safeParse(candidate);
+    if (currentShapeResult.success) {
+      normalizedOutput.push(
+        safeStructuredClone(currentShapeResult.data as OutputItem)
+      );
+      continue;
+    }
+
     if (
       isRecord(candidate) &&
       getStringProperty(candidate, "type") === "message"
@@ -1391,7 +1447,7 @@ export const normalizeRequest = async (
 
   return {
     inputItems: replayedInputItems,
-    messages: replayedInputItems.map(inputItemToMessage),
+    messages: replayedInputItems.flatMap(inputItemToMessages),
     requestSnapshot: buildRequestSnapshot({
       request: parsedRequest,
       inputItems: replayedInputItems,

--- a/packages/openresponses-adapter/src/server/previous-response.ts
+++ b/packages/openresponses-adapter/src/server/previous-response.ts
@@ -919,20 +919,19 @@ const inputItemToMessages = (item: InputItem): LangChainMessageLike[] => {
   }
 
   if (item.type === "reasoning") {
-    const content = item.summary
+    const summaryText = item.summary
       .map(reasoningSummaryPartToText)
       .filter((part) => part.length > 0)
       .join(" ");
-
-    if (content.length === 0) {
-      return [];
-    }
 
     return [
       {
         type: "ai",
         role: "assistant",
-        content,
+        content: summaryText.length > 0 ? summaryText : [],
+        additional_kwargs: {
+          reasoning: safeStructuredClone(item),
+        },
       },
     ];
   }

--- a/packages/openresponses-adapter/tests/fake-model.spec.ts
+++ b/packages/openresponses-adapter/tests/fake-model.spec.ts
@@ -88,4 +88,49 @@ describe("fake model regression", () => {
       },
     ]);
   });
+
+  test("accepts reasoning and item_reference input items without crashing", async () => {
+    const agent = createFakeAgent();
+    const adapter = createOpenResponsesAdapter({ agent });
+
+    const response = await adapter.invoke({
+      model: "gpt-4.1-mini",
+      input: [
+        {
+          type: "item_reference",
+          id: "msg_123",
+        },
+        {
+          type: "reasoning",
+          id: "rs_123",
+          summary: [
+            { type: "summary_text", text: "Earlier reasoning summary" },
+          ],
+        },
+        {
+          type: "message",
+          role: "user",
+          content: "Continue.",
+        },
+      ],
+      metadata: {},
+      tools: [],
+      parallel_tool_calls: true,
+      stream: false,
+    });
+
+    expect(response.status).toBe("completed");
+    expect(agent.__getLastInvokeInput()?.messages).toEqual([
+      {
+        type: "ai",
+        role: "assistant",
+        content: "Earlier reasoning summary",
+      },
+      {
+        type: "human",
+        role: "user",
+        content: "Continue.",
+      },
+    ]);
+  });
 });

--- a/packages/openresponses-adapter/tests/fake-model.spec.ts
+++ b/packages/openresponses-adapter/tests/fake-model.spec.ts
@@ -89,7 +89,7 @@ describe("fake model regression", () => {
     ]);
   });
 
-  test("accepts reasoning and item_reference input items without crashing", async () => {
+  test("preserves reasoning input payload in additional_kwargs without crashing", async () => {
     const agent = createFakeAgent();
     const adapter = createOpenResponsesAdapter({ agent });
 
@@ -106,6 +106,7 @@ describe("fake model regression", () => {
           summary: [
             { type: "summary_text", text: "Earlier reasoning summary" },
           ],
+          encrypted_content: "opaque-reasoning-payload",
         },
         {
           type: "message",
@@ -125,6 +126,16 @@ describe("fake model regression", () => {
         type: "ai",
         role: "assistant",
         content: "Earlier reasoning summary",
+        additional_kwargs: {
+          reasoning: {
+            type: "reasoning",
+            id: "rs_123",
+            summary: [
+              { type: "summary_text", text: "Earlier reasoning summary" },
+            ],
+            encrypted_content: "opaque-reasoning-payload",
+          },
+        },
       },
       {
         type: "human",

--- a/packages/openresponses-adapter/tests/helpers/streaming-fixtures.ts
+++ b/packages/openresponses-adapter/tests/helpers/streaming-fixtures.ts
@@ -87,6 +87,20 @@ export function* simulateFailureStream(
   throw new Error("model crashed");
 }
 
+export function* simulateIncompleteStream(
+  _input: { messages: LangChainMessageLike[] },
+  config: Record<string, unknown>
+): Iterable<unknown> {
+  const bridge = extractBridge(config);
+  const runId = extractRunId(config);
+
+  bridge.handleChatModelStart?.({}, [[]], runId, undefined);
+  yield { type: "chunk", content: "" };
+
+  bridge.handleLLMNewToken?.("Partial", undefined, runId);
+  yield { type: "chunk", content: "Partial" };
+}
+
 export function* simulateToolCallStream(
   _input: { messages: LangChainMessageLike[] },
   config: Record<string, unknown>
@@ -120,6 +134,42 @@ export function* simulateToolCallStream(
   yield { type: "chunk", content: "" };
 
   bridge.handleToolEnd?.({ temperature: "55F" }, "tool-run-1", runId);
+  yield { type: "chunk", content: "" };
+
+  bridge.handleAgentEnd?.({}, runId);
+}
+
+export function* simulateReasoningSummaryStream(
+  _input: { messages: LangChainMessageLike[] },
+  config: Record<string, unknown>
+): Iterable<unknown> {
+  const bridge = extractBridge(config);
+  const runId = extractRunId(config);
+
+  bridge.handleChatModelStart?.({}, [[]], runId, undefined);
+  yield { type: "chunk", content: "" };
+
+  bridge.handleLLMNewToken?.("", undefined, runId, undefined, undefined, {
+    chunk: {
+      message: {
+        contentBlocks: [{ type: "reasoning_text", text: "Thinking step 1" }],
+      },
+    },
+  });
+  yield { type: "chunk", content: "" };
+
+  bridge.handleLLMEnd?.(
+    {
+      message: {
+        content: [
+          { type: "reasoning_text", text: "Thinking step 1" },
+          { type: "summary_text", text: "Short answer summary" },
+        ],
+      },
+      generations: [],
+    },
+    runId
+  );
   yield { type: "chunk", content: "" };
 
   bridge.handleAgentEnd?.({}, runId);

--- a/packages/openresponses-adapter/tests/unit/event-serializer.test.ts
+++ b/packages/openresponses-adapter/tests/unit/event-serializer.test.ts
@@ -436,7 +436,7 @@ describe("serializeInternalEvent", () => {
     expect(context.lifecycle.getStatus()).toBe("in_progress");
   });
 
-  test("run.failed emits response.failed", () => {
+  test("run.failed emits error then response.failed", () => {
     const context = createContext();
     serializeInternalEvent({ type: "run.started", runId: "run-1" }, context);
 
@@ -445,16 +445,59 @@ describe("serializeInternalEvent", () => {
       context
     );
 
-    expect(events).toHaveLength(1);
-    expect(events[0]?.type).toBe("response.failed");
-    if (events[0]?.type === "response.failed") {
-      expect(events[0].response.id).toBe("resp-1");
-      expect(events[0].response.status).toBe("failed");
-      expect(events[0].response.error).toMatchObject({
+    expect(events).toHaveLength(2);
+    expect(events[0]?.type).toBe("error");
+    if (events[0]?.type === "error") {
+      expect(events[0].error).toMatchObject({
         type: "model_error",
         message: "boom",
       });
     }
+    expect(events[1]?.type).toBe("response.failed");
+    if (events[1]?.type === "response.failed") {
+      expect(events[1].response.id).toBe("resp-1");
+      expect(events[1].response.status).toBe("failed");
+      expect(events[1].response.error).toMatchObject({
+        type: "model_error",
+        message: "boom",
+      });
+    }
+  });
+
+  test("reasoning.completed emits summary-part events before output_item.done", () => {
+    const context = createContext();
+    serializeInternalEvent({ type: "run.started", runId: "run-1" }, context);
+    serializeInternalEvent(
+      { type: "reasoning.started", itemId: "reasoning-1", runId: "run-1" },
+      context
+    );
+    serializeInternalEvent(
+      {
+        type: "reasoning.delta",
+        itemId: "reasoning-1",
+        delta: "Thinking step 1",
+      },
+      context
+    );
+
+    const events = serializeInternalEvent(
+      {
+        type: "reasoning.completed",
+        itemId: "reasoning-1",
+        summaryTexts: ["Short answer summary"],
+      },
+      context
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      "response.reasoning.done",
+      "response.content_part.done",
+      "response.reasoning_summary_part.added",
+      "response.reasoning_summary_text.delta",
+      "response.reasoning_summary_text.done",
+      "response.reasoning_summary_part.done",
+      "response.output_item.done",
+    ]);
   });
 
   test("run.failed from a sub-run does not fail the response lifecycle", () => {
@@ -585,7 +628,7 @@ describe("createEventSerializer", () => {
     expect(seqNums).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
   });
 
-  test("queue failure emits response.failed + [DONE]", async () => {
+  test("queue failure emits error + response.failed + [DONE]", async () => {
     const queue = createAsyncEventQueue<InternalSemanticEvent>();
     const generateId = createSequentialIdGenerator(["item-1"]);
     const accumulator = createCanonicalItemAccumulator({ generateId });
@@ -617,12 +660,13 @@ describe("createEventSerializer", () => {
       "response.output_item.added",
       "response.content_part.added",
       "response.output_text.delta",
+      "error",
       "response.failed",
       "[DONE]",
     ]);
   });
 
-  test("run.failed mid-stream emits failed + [DONE]", async () => {
+  test("run.failed mid-stream emits error + failed + [DONE]", async () => {
     const queue = createAsyncEventQueue<InternalSemanticEvent>();
     const generateId = createSequentialIdGenerator(["item-1"]);
     const accumulator = createCanonicalItemAccumulator({ generateId });
@@ -659,6 +703,7 @@ describe("createEventSerializer", () => {
       "response.output_item.added",
       "response.content_part.added",
       "response.output_text.delta",
+      "error",
       "response.failed",
       "[DONE]",
     ]);

--- a/packages/openresponses-adapter/tests/unit/event-serializer.test.ts
+++ b/packages/openresponses-adapter/tests/unit/event-serializer.test.ts
@@ -412,8 +412,12 @@ describe("serializeInternalEvent", () => {
       context
     );
 
-    expect(events).toHaveLength(1);
+    expect(events).toHaveLength(2);
     expect(events[0]).toMatchObject({
+      type: "response.in_progress",
+      response: { id: "resp-1", object: "response", status: "in_progress" },
+    });
+    expect(events[1]).toMatchObject({
       type: "response.completed",
       response: { id: "resp-1", object: "response", status: "completed" },
     });
@@ -462,6 +466,22 @@ describe("serializeInternalEvent", () => {
         message: "boom",
       });
     }
+  });
+
+  test("run.failed emits response.in_progress first when no prior in-progress event was emitted", () => {
+    const context = createContext();
+
+    const events = serializeInternalEvent(
+      { type: "run.failed", runId: "resp-1", error: new Error("boom") },
+      context
+    );
+
+    expect(events.map((event) => event.type)).toEqual([
+      "response.in_progress",
+      "error",
+      "response.failed",
+    ]);
+    expect(context.lifecycle.getStatus()).toBe("failed");
   });
 
   test("reasoning.completed emits summary-part events before output_item.done", () => {

--- a/packages/openresponses-adapter/tests/unit/previous-response-store.test.ts
+++ b/packages/openresponses-adapter/tests/unit/previous-response-store.test.ts
@@ -99,4 +99,38 @@ describe("InMemoryPreviousResponseStore", () => {
 
     expect(secondLoad?.request.metadata.source).toBe("test");
   });
+
+  test("preserves current-shape reasoning and function_call_output items on round-trip", async () => {
+    const store = createInMemoryPreviousResponseStore();
+    const record = createRecord();
+
+    record.response.output = [
+      {
+        id: "reasoning-1",
+        type: "reasoning",
+        content: [{ type: "reasoning_text", text: "Need to compare options." }],
+        summary: [{ type: "summary_text", text: "Compare the options." }],
+      },
+      {
+        id: "call-1",
+        type: "function_call",
+        call_id: "call-1",
+        name: "lookup_fact",
+        arguments: '{"topic":"road"}',
+        status: "completed",
+      },
+      {
+        id: "tool-1",
+        type: "function_call_output",
+        call_id: "call-1",
+        output: '{"result":"because tests do that"}',
+        status: "completed",
+      },
+    ];
+
+    await store.save(record);
+    const loaded = await store.load("resp-1");
+
+    expect(loaded?.response.output).toEqual(record.response.output);
+  });
 });

--- a/packages/openresponses-adapter/tests/unit/streaming.test.ts
+++ b/packages/openresponses-adapter/tests/unit/streaming.test.ts
@@ -18,6 +18,7 @@ import {
   createInMemoryPreviousResponseStore,
   createSequentialIdGenerator,
 } from "@/testing/index.js";
+import { simulateReasoningSummaryStream } from "../helpers/streaming-fixtures.ts";
 
 type StreamCallback = (
   input: { messages: LangChainMessageLike[] },
@@ -147,42 +148,6 @@ function* simulateToolCallStream(
   yield { type: "chunk", content: "" };
 
   bridge.handleToolEnd?.({ temperature: "55F" }, "tool-run-1", runId);
-  yield { type: "chunk", content: "" };
-
-  bridge.handleAgentEnd?.({}, runId);
-}
-
-function* simulateReasoningSummaryStream(
-  _input: { messages: LangChainMessageLike[] },
-  config: Record<string, unknown>
-): Iterable<unknown> {
-  const bridge = extractBridge(config);
-  const runId = extractRunId(config);
-
-  bridge.handleChatModelStart?.({}, [[]], runId, undefined);
-  yield { type: "chunk", content: "" };
-
-  bridge.handleLLMNewToken?.("", undefined, runId, undefined, undefined, {
-    chunk: {
-      message: {
-        contentBlocks: [{ type: "reasoning_text", text: "Thinking step 1" }],
-      },
-    },
-  });
-  yield { type: "chunk", content: "" };
-
-  bridge.handleLLMEnd?.(
-    {
-      message: {
-        content: [
-          { type: "reasoning_text", text: "Thinking step 1" },
-          { type: "summary_text", text: "Short answer summary" },
-        ],
-      },
-      generations: [],
-    },
-    runId
-  );
   yield { type: "chunk", content: "" };
 
   bridge.handleAgentEnd?.({}, runId);

--- a/packages/openresponses-adapter/tests/unit/streaming.test.ts
+++ b/packages/openresponses-adapter/tests/unit/streaming.test.ts
@@ -152,6 +152,42 @@ function* simulateToolCallStream(
   bridge.handleAgentEnd?.({}, runId);
 }
 
+function* simulateReasoningSummaryStream(
+  _input: { messages: LangChainMessageLike[] },
+  config: Record<string, unknown>
+): Iterable<unknown> {
+  const bridge = extractBridge(config);
+  const runId = extractRunId(config);
+
+  bridge.handleChatModelStart?.({}, [[]], runId, undefined);
+  yield { type: "chunk", content: "" };
+
+  bridge.handleLLMNewToken?.("", undefined, runId, undefined, undefined, {
+    chunk: {
+      message: {
+        contentBlocks: [{ type: "reasoning_text", text: "Thinking step 1" }],
+      },
+    },
+  });
+  yield { type: "chunk", content: "" };
+
+  bridge.handleLLMEnd?.(
+    {
+      message: {
+        content: [
+          { type: "reasoning_text", text: "Thinking step 1" },
+          { type: "summary_text", text: "Short answer summary" },
+        ],
+      },
+      generations: [],
+    },
+    runId
+  );
+  yield { type: "chunk", content: "" };
+
+  bridge.handleAgentEnd?.({}, runId);
+}
+
 function* simulateMultiRunToolStream(
   _input: { messages: LangChainMessageLike[] },
   config: Record<string, unknown>
@@ -429,6 +465,7 @@ describe("adapter.stream()", () => {
 
     expect(types).toContain("response.in_progress");
     expect(types).toContain("response.output_text.delta");
+    expect(types).toContain("error");
     expect(types).toContain("response.failed");
     expect(types.at(-1)).toBe("[DONE]");
 
@@ -462,8 +499,53 @@ describe("adapter.stream()", () => {
     const events = await collectStream(stream);
 
     const types = events.map((e) => (typeof e === "string" ? e : e.type));
+    expect(types).toContain("error");
     expect(types).toContain("response.failed");
     expect(types.at(-1)).toBe("[DONE]");
+  });
+
+  test("reasoning summaries emit summary events before output_item.done", async () => {
+    const adapter = createOpenResponsesAdapter({
+      agent: createCallbackDrivenAgent({
+        onStream: simulateReasoningSummaryStream,
+      }),
+      clock: createDeterministicClock(1000),
+      generateId: createSequentialIdGenerator(["resp-1", "reasoning-1"]),
+    });
+
+    const stream = await adapter.stream(baseRequest);
+    const events = await collectStream(stream);
+    const types = events.map((event) =>
+      typeof event === "string" ? event : event.type
+    );
+
+    expect(types).toContain("response.reasoning_summary_part.added");
+    expect(types).toContain("response.reasoning_summary_text.delta");
+    expect(types).toContain("response.reasoning_summary_text.done");
+    expect(types).toContain("response.reasoning_summary_part.done");
+
+    const itemDoneIndex = types.indexOf("response.output_item.done");
+    const summaryDoneIndex = types.indexOf(
+      "response.reasoning_summary_part.done"
+    );
+    expect(summaryDoneIndex).toBeGreaterThan(-1);
+    expect(summaryDoneIndex).toBeLessThan(itemDoneIndex);
+
+    const completedEvent = events.find((event) => {
+      return typeof event !== "string" && event.type === "response.completed";
+    });
+
+    expect(completedEvent).toBeDefined();
+    if (completedEvent && typeof completedEvent !== "string") {
+      expect(completedEvent.response.output).toEqual([
+        {
+          id: "reasoning-1",
+          type: "reasoning",
+          content: [{ type: "reasoning_text", text: "Thinking step 1" }],
+          summary: [{ type: "summary_text", text: "Short answer summary" }],
+        },
+      ]);
+    }
   });
 
   test("pre-stream validation error rejects the promise", async () => {
@@ -527,6 +609,7 @@ describe("adapter.stream()", () => {
     ).toEqual([
       "response.created",
       "response.queued",
+      "error",
       "response.failed",
       "[DONE]",
     ]);

--- a/packages/openresponses-adapter/tests/unit/streaming.test.ts
+++ b/packages/openresponses-adapter/tests/unit/streaming.test.ts
@@ -574,6 +574,7 @@ describe("adapter.stream()", () => {
     ).toEqual([
       "response.created",
       "response.queued",
+      "response.in_progress",
       "error",
       "response.failed",
       "[DONE]",


### PR DESCRIPTION
## Summary

This PR elevates `@skroyc/openresponses-adapter` beyond the six-scenario official runner baseline by adding a package-owned JSON-surface spec-conformance layer on top of the pinned OpenResponses snapshot.

It keeps the vendored official runner as the upstream acceptance gate, adds a requirement-to-proof matrix for the JSON request surface, and closes a set of runner-uncovered protocol gaps in the streaming path.

## What changed

- added `contracts/openresponses/REQUIREMENT-MATRIX.md` to track pinned-snapshot JSON-surface requirements against proof sources
- added `bun run test:compliance:spec` and `bun run test:compliance:full`
- added `scripts/run-spec-conformance.ts` to run built-package black-box conformance checks against the public HTTP surface
- tightened README/package claims to JSON-surface conformance rather than broader transport claims
- updated streaming serialization to emit `error` before terminal `response.failed`
- added reasoning-summary streaming family coverage when summary text is available
- updated unit and streaming tests to validate the new event ordering and terminal semantics

## Scope and boundaries

- in scope: pinned OpenResponses JSON request surface
- intentionally out of scope for this PR: `application/x-www-form-urlencoded`
- the requirement matrix explicitly marks broader continuation/tool-governance proof as partial where the official runner provides baseline coverage but not full normative proof

## Verification

Ran successfully:

- `bun test tests/unit/event-serializer.test.ts tests/unit/streaming.test.ts`
- `bun run test:compliance:spec`
- `bun run test:compliance:official`
- `bun run typecheck`
- `bun run lint`

## Notes

This PR is aimed at making the package's compliance posture more truthful and auditable:

- official runner pass remains necessary but insufficient on its own
- package-owned proof now covers JSON-surface framing, terminal failure semantics, incomplete terminal semantics, and reasoning-summary streaming coverage

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skroyc/langchain-middlewares-callbacks-ts/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
