### PR TITLE
Fix persistence and replay fidelity in openresponses adapter

### DIFF
--- a/packages/openresponses-adapter/README.md
+++ b/packages/openresponses-adapter/README.md
@@ -6,7 +6,7 @@ It exposes a `POST /v1/responses` route, preserves `previous_response_id` replay
 
 ## Status
 
-This package targets conformance with the pinned OpenResponses snapshot for the JSON request surface, uses the official OpenResponses CLI runner as a baseline release gate, and adds a package-owned spec-conformance suite for runner-uncovered behaviors. That suite also retains a small set of stricter package invariants where the pinned upstream wording is softer or leaves behavior unspecified.
+This package currently claims conformance with the pinned OpenResponses snapshot for the JSON request surface, uses the official OpenResponses CLI runner as a baseline release gate, and adds a package-owned spec-conformance suite for selected runner-uncovered behaviors. The current claimed scope is tracked in `contracts/openresponses/REQUIREMENT-MATRIX.md`, and broader full pinned-spec conformance remains pending explicit proof closure.
 
 Implemented release-blocker capabilities:
 

--- a/packages/openresponses-adapter/docs/Architecture.md
+++ b/packages/openresponses-adapter/docs/Architecture.md
@@ -10,7 +10,7 @@
 
 ## 1. Architectural Strategy & Archetype Alignment
 - **Architectural Pattern:** Contract-authoritative modular monolith library with event-serialized streaming and builder-controlled continuation persistence.
-- **Why this pattern fits the PRD:** The product remains a library package adopted inside an existing agent host, so a modular monolith keeps solo-dev operations small while still allowing one authoritative response assembly pipeline to own the full current OpenResponses contract. Full compliance increases contract and state complexity, but it does not justify distributed deployment boundaries.
+- **Why this pattern fits the PRD:** The product remains a library package adopted inside an existing agent host, so a modular monolith keeps solo-dev operations small while still allowing one authoritative response assembly pipeline to own the pinned JSON-surface contract for the current release scope. Snapshot-aligned compliance increases contract and state complexity, but it does not justify distributed deployment boundaries.
 - **Core trade-offs accepted:** More internal state assembly and contract validation complexity is accepted to eliminate partial public resources, terminal streaming stubs, and drift against the official OpenResponses surface.
 
 ### Standards Posture
@@ -21,7 +21,7 @@
 
 ### Brownfield Starting Point
 - The current codebase already contains the core logical pieces required for this architecture: public route publication, request normalization, callback observation, canonical response state, tool policy mediation, and continuation persistence.
-- The current codebase now realizes the pinned current contract for the vendored snapshot, with the official runner and built-package smoke checks acting as release validation rather than aspirational targets.
+- The current codebase now implements the pinned JSON-surface release target for the vendored snapshot, with the official runner and built-package smoke checks acting as release validation for the current milestone while broader pinned-spec proof remains open.
 
 ### Brownfield Rules Carried Forward
 - The agent runtime remains the execution engine, not the public protocol authority. The package is responsible for request normalization, public contract assembly, and truth-preserving publication.

--- a/packages/openresponses-adapter/docs/PRD.md
+++ b/packages/openresponses-adapter/docs/PRD.md
@@ -9,7 +9,7 @@
 
 ## 1. Executive Summary & Target Archetype
 - **Target Archetype:** Library package that exposes a standards-compliant HTTP adapter over an existing agent runtime.
-- **Vision:** A solo builder can expose an existing LangChain agent through a `/v1/responses` surface that satisfies the full current OpenResponses contract and works with Responses-style SDK clients and the official compliance runner without bespoke protocol glue.
+- **Vision:** A solo builder can expose an existing LangChain agent through a `/v1/responses` surface that satisfies the pinned JSON-surface release target, works with Responses-style SDK clients and the official compliance runner, and leaves broader pinned-spec proof explicit rather than implied.
 - **Problem:** Partial-compatible adapters fail when clients and the official OpenResponses validation workflow expect a full `ResponseResource`, full terminal streaming response payloads, richer event families, and broader contract fidelity than a spec-minimal MVP provides.
 - **Jobs to Be Done:** When a builder already has a working agent runtime, they want to mount a package that makes that runtime behave like a fully compliant OpenResponses endpoint, preserves truthful live execution semantics, supports tools and continuation correctly, and gives them a real black-box validation workflow before release.
 
@@ -22,7 +22,7 @@
 
 ### Product Posture
 - Contract truth beats convenience.
-- Full current compliance beats partial compatibility.
+- Truthful pinned-snapshot claims beat inflated compatibility claims.
 - Library-first adoption beats platform sprawl.
 - Hosted-service scope remains explicitly excluded.
 
@@ -153,7 +153,7 @@
 - **Viability Risk:** As a pure OSS utility, the package must stay narrow even while broadening the protocol contract. Hosted persistence, platform features, or framework sprawl would create maintenance cost disproportionate to ecosystem value.
 
 ### 5.2 Release Priorities & Success Criteria
-- **Release Now:** Full current `/v1/responses` contract fidelity, full terminal streaming resources, current tool-contract fidelity, explicit response-ID continuation, current compliant input coverage, and official compliance-runner pass as a release gate.
+- **Release Now:** Pinned JSON-surface `/v1/responses` contract fidelity, full terminal streaming resources, current tool-contract fidelity, explicit response-ID continuation, current compliant input coverage, and official compliance-runner pass as a release gate.
 - **Phase 2:** Broader runtime bindings, richer advanced integration surfaces, stronger observability and contract-drift tooling, and additional contract coverage beyond the current official acceptance scenarios.
 - **Deferred:** Hosted platform behavior, non-generic provider-native capabilities, and broader multimodal ambitions outside the current published OpenResponses contract.
 - **Primary Success Metric:** A built package passes the official OpenResponses compliance suite against a live server on the certified runtimes.
@@ -161,7 +161,7 @@
 
 ## 6. Boundary Analysis
 ### In Scope
-- Full current OpenResponses `/v1/responses` contract fidelity for the current published contract snapshot
+- Pinned JSON-surface `/v1/responses` contract fidelity for the current release milestone
 - Full non-streaming `ResponseResource` shape
 - Full terminal streaming response payloads
 - Current published streaming event families required for compliant operation

--- a/packages/openresponses-adapter/docs/Tasks.md
+++ b/packages/openresponses-adapter/docs/Tasks.md
@@ -16,7 +16,7 @@
 
 The active plan still follows the original constraint logic from the MVP phase: the real risk concentration is truthful semantic publication under a broader contract. The pacing chain remains contract authority -> canonical state -> publication breadth -> release proof. Request broadening, stored-record migration, and release documentation are sequenced to support that path rather than compete with it.
 
-Implementation status: the original ORA chain is implemented for the pinned upstream acceptance baseline. The additional delta below upgrades the target to full pinned-spec conformance proof rather than official-runner success alone.
+Implementation status: the original ORA chain is implemented for the pinned upstream acceptance baseline and current JSON-surface proof target. The additional delta below upgrades the target to fuller pinned-spec conformance proof rather than official-runner success alone.
 
 ### Legacy Issue Mapping Policy
 - `ORL-*` remains the archived MVP baseline that produced the current brownfield package.
@@ -66,7 +66,7 @@ Implementation status: the original ORA chain is implemented for the pinned upst
 ### Active Verification Milestones
 - **Milestone 1:** Completed. The pinned contract snapshot and official runner harness execute mechanically against a live built package.
 - **Milestone 2:** Completed. Local regressions and official black-box compliance both exercise the broadened response, continuation, and streaming surface without conflating their roles.
-- **Milestone 3:** Completed. CI, import smoke, examples, and release-facing docs now reflect the full-compliance posture rather than the old MVP subset claim.
+- **Milestone 3:** Completed. CI, import smoke, examples, and release-facing docs now reflect the narrowed JSON-surface posture rather than the old MVP subset claim.
 - **Milestone 4:** Pending. Every normative pinned-spec requirement is mapped to official-runner proof, package-owned proof, or an explicit uncovered gap.
 - **Milestone 5:** Pending. The package closes all runner-uncovered normative gaps and only then claims full pinned-spec compliance.
 

--- a/packages/openresponses-adapter/docs/TechSpec.md
+++ b/packages/openresponses-adapter/docs/TechSpec.md
@@ -18,9 +18,10 @@
 
 ### 1.1 Brownfield Audit Summary
 - **Current package reality:** The package already contains the core machinery needed for the target state: request normalization, callback-driven semantic observation, canonical state accumulation, continuation persistence, Hono publication, and dual-runtime smoke coverage.
-- **Current package reality:** The package now satisfies the pinned target contract for the current vendored snapshot and official CLI runner baseline.
+- **Current package reality:** The package now satisfies the current pinned JSON-surface release target and official CLI runner baseline for the vendored snapshot.
 - **Current release reality:** `tests/compliance/local-regression.spec.ts` is a useful package-local regression harness, but it is not equivalent to the official OpenResponses CLI runner and must not be treated as contract proof.
 - **Current release reality:** Official compliance, package-owned pinned-spec conformance checks, Node 24 smoke, and Bun smoke are release gates; local regressions remain supporting evidence only.
+- **Current claim scope:** `contracts/openresponses/REQUIREMENT-MATRIX.md` defines the currently claimed JSON-surface proof boundary; broader full pinned-spec conformance remains pending explicit matrix closure.
 - **Sustained implication:** Ongoing work is primarily snapshot refresh review, docs drift control, and compatibility maintenance rather than a topology rewrite.
 
 ## 2. Architecture Decision Records (ADRs)

--- a/packages/openresponses-adapter/package.json
+++ b/packages/openresponses-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@skroyc/openresponses-adapter",
   "version": "0.1.0",
-  "description": "Open Responses adapter for LangChain agents with pinned-snapshot JSON-surface compliance, truthful SSE streaming, and official runner + spec-conformance release gating",
+  "description": "Open Responses adapter for LangChain agents with pinned-snapshot JSON-surface compliance, truthful SSE streaming, and official runner baseline + spec-conformance checks",
   "keywords": [
     "langchain",
     "open-responses",

--- a/packages/openresponses-adapter/src/server/adapter.ts
+++ b/packages/openresponses-adapter/src/server/adapter.ts
@@ -539,17 +539,7 @@ export function createOpenResponsesAdapter(
           createdAt,
           completedAt: lifecycle.getCompletedAt(),
           status,
-          output: accumulator.snapshot().filter((item) => {
-            if (item.type === "function_call") {
-              return !replayedCallIds.has(item.call_id);
-            }
-
-            if (item.type === "function_call_output") {
-              return !replayedCallIds.has(item.call_id);
-            }
-
-            return true;
-          }),
+          output: accumulator.snapshot(),
           error: lifecycle.getError(),
         });
 

--- a/packages/openresponses-adapter/src/server/previous-response.ts
+++ b/packages/openresponses-adapter/src/server/previous-response.ts
@@ -1309,10 +1309,33 @@ const repairRequestSnapshot = (params: {
     >(requestRecord, "stream_options"),
   });
 
-  return buildRequestSnapshot({
+  const repairedSnapshot = buildRequestSnapshot({
     request: repairedRequest,
     inputItems: inputToItems(repairedRequest.input),
   });
+
+  const rawInputItems = Array.isArray(requestRecord.input) ? requestRecord.input : [];
+  repairedSnapshot.input = repairedSnapshot.input.map((item, index) => {
+    if (item.type !== "reasoning") {
+      return item;
+    }
+
+    const rawInputItem = rawInputItems[index];
+    if (!isRecord(rawInputItem) || rawInputItem.type !== "reasoning") {
+      return item;
+    }
+
+    if (!("content" in rawInputItem) || rawInputItem.content === undefined) {
+      return item;
+    }
+
+    return {
+      ...item,
+      content: safeStructuredClone(rawInputItem.content),
+    } as InputItem;
+  });
+
+  return repairedSnapshot;
 };
 
 const repairStoredResponseResource = (params: {

--- a/packages/openresponses-adapter/src/server/previous-response.ts
+++ b/packages/openresponses-adapter/src/server/previous-response.ts
@@ -1314,7 +1314,9 @@ const repairRequestSnapshot = (params: {
     inputItems: inputToItems(repairedRequest.input),
   });
 
-  const rawInputItems = Array.isArray(requestRecord.input) ? requestRecord.input : [];
+  const rawInputItems = Array.isArray(requestRecord.input)
+    ? requestRecord.input
+    : [];
   repairedSnapshot.input = repairedSnapshot.input.map((item, index) => {
     if (item.type !== "reasoning") {
       return item;

--- a/packages/openresponses-adapter/src/server/previous-response.ts
+++ b/packages/openresponses-adapter/src/server/previous-response.ts
@@ -370,15 +370,11 @@ const outputItemToInputItem = (item: OutputItem): InputItem => {
     return {
       type: "reasoning",
       id: item.id,
-      summary: item.summary
-        .map((part) => {
-          return "text" in part
-            ? ({ type: "summary_text", text: part.text } as const)
-            : null;
-        })
-        .filter((part) => {
-          return part !== null;
-        }),
+      summary: item.summary.flatMap((part) => {
+        return part.type === "summary_text"
+          ? [{ type: "summary_text", text: part.text } as const]
+          : [];
+      }),
       ...(item.content ? { content: safeStructuredClone(item.content) } : {}),
       ...("encrypted_content" in item && item.encrypted_content !== undefined
         ? { encrypted_content: item.encrypted_content }

--- a/packages/openresponses-adapter/src/server/previous-response.ts
+++ b/packages/openresponses-adapter/src/server/previous-response.ts
@@ -368,13 +368,21 @@ const outputItemToInputItem = (item: OutputItem): InputItem => {
 
   if (item.type === "reasoning") {
     return {
-      type: "message",
-      role: "assistant",
-      content: item.summary
+      type: "reasoning",
+      id: item.id,
+      summary: item.summary
         .map((part) => {
-          return "text" in part ? part.text : "";
+          return "text" in part
+            ? ({ type: "summary_text", text: part.text } as const)
+            : null;
         })
-        .join(" "),
+        .filter((part) => {
+          return part !== null;
+        }),
+      ...(item.content ? { content: safeStructuredClone(item.content) } : {}),
+      ...("encrypted_content" in item && item.encrypted_content !== undefined
+        ? { encrypted_content: item.encrypted_content }
+        : {}),
     };
   }
 

--- a/packages/openresponses-adapter/src/server/previous-response.ts
+++ b/packages/openresponses-adapter/src/server/previous-response.ts
@@ -400,6 +400,31 @@ const outputItemToInputItem = (item: OutputItem): InputItem => {
   };
 };
 
+const getReplayToolItemKey = (item: InputItem): string | null => {
+  if (item.type === "function_call" || item.type === "function_call_output") {
+    return `${item.type}:${item.call_id}`;
+  }
+
+  return null;
+};
+
+const dedupeReplayedResponseItems = (params: {
+  priorRequestItems: InputItem[];
+  priorResponseItems: InputItem[];
+}): InputItem[] => {
+  const replayedToolItemKeys = new Set(
+    params.priorRequestItems.flatMap((item) => {
+      const key = getReplayToolItemKey(item);
+      return key ? [key] : [];
+    })
+  );
+
+  return params.priorResponseItems.filter((item) => {
+    const key = getReplayToolItemKey(item);
+    return key === null || !replayedToolItemKeys.has(key);
+  });
+};
+
 const normalizeOutputItemStatus = (
   status: unknown
 ): "in_progress" | "completed" | "incomplete" => {
@@ -1437,8 +1462,11 @@ export const normalizeRequest = async (
     );
 
     const priorRequestItems = inputToItems(validatedRecord.request.input);
-    const priorResponseItems = validatedRecord.response.output.map((item) => {
-      return outputItemToInputItem(item as unknown as OutputItem);
+    const priorResponseItems = dedupeReplayedResponseItems({
+      priorRequestItems,
+      priorResponseItems: validatedRecord.response.output.map((item) => {
+        return outputItemToInputItem(item as unknown as OutputItem);
+      }),
     });
 
     replayedInputItems = [

--- a/packages/openresponses-adapter/tests/unit/continuation-replay.test.ts
+++ b/packages/openresponses-adapter/tests/unit/continuation-replay.test.ts
@@ -182,6 +182,86 @@ describe("continuation replay", () => {
     ]);
   });
 
+  test("replays prior reasoning output items as reasoning payloads", async () => {
+    const store = createInMemoryPreviousResponseStore();
+    await store.save({
+      response_id: "resp-reasoning",
+      request: createRequestSnapshot({
+        include: ["reasoning.encrypted_content"],
+      }),
+      response: createTerminalResponse({
+        id: "resp-reasoning",
+        output: [
+          {
+            type: "reasoning",
+            id: "rs_123",
+            content: [{ type: "reasoning_text", text: "Detailed reasoning" }],
+            summary: [
+              { type: "summary_text", text: "Earlier reasoning summary" },
+            ],
+            encrypted_content: "opaque-reasoning-payload",
+          },
+        ],
+      }),
+      status: "completed",
+      created_at: 1000,
+      completed_at: 2000,
+      contract_snapshot_version: contractSnapshotVersion,
+    });
+
+    const agent = createFakeAgent({
+      responses: [{ type: "ai", id: "ai-reasoning", content: "Done" }],
+    });
+    const adapter = createOpenResponsesAdapter({
+      agent,
+      previousResponseStore: store,
+    });
+
+    await adapter.invoke({
+      model: "gpt-4.1-mini",
+      previous_response_id: "resp-reasoning",
+      input: "Continue.",
+      metadata: {},
+      tools: [],
+      parallel_tool_calls: true,
+      stream: false,
+    });
+
+    expect(agent.__getLastInvokeInput()?.messages).toEqual([
+      {
+        type: "system",
+        role: "system",
+        content: [{ type: "input_text", text: "Be terse." }],
+      },
+      {
+        type: "human",
+        role: "user",
+        content: "Tell me a joke",
+      },
+      {
+        type: "ai",
+        role: "assistant",
+        content: "Earlier reasoning summary",
+        additional_kwargs: {
+          reasoning: {
+            type: "reasoning",
+            id: "rs_123",
+            content: [{ type: "reasoning_text", text: "Detailed reasoning" }],
+            summary: [
+              { type: "summary_text", text: "Earlier reasoning summary" },
+            ],
+            encrypted_content: "opaque-reasoning-payload",
+          },
+        },
+      },
+      {
+        type: "human",
+        role: "user",
+        content: "Continue.",
+      },
+    ]);
+  });
+
   test("maps tool-call history input items to LangChain-compatible messages", async () => {
     const agent = createFakeAgent();
     const adapter = createOpenResponsesAdapter({ agent });

--- a/packages/openresponses-adapter/tests/unit/continuation-replay.test.ts
+++ b/packages/openresponses-adapter/tests/unit/continuation-replay.test.ts
@@ -262,6 +262,120 @@ describe("continuation replay", () => {
     ]);
   });
 
+  test("preserves reasoning content across chained continuations", async () => {
+    const store = createInMemoryPreviousResponseStore();
+    await store.save({
+      response_id: "resp-reasoning",
+      request: createRequestSnapshot({
+        include: ["reasoning.encrypted_content"],
+      }),
+      response: createTerminalResponse({
+        id: "resp-reasoning",
+        output: [
+          {
+            type: "reasoning",
+            id: "rs_123",
+            content: [{ type: "reasoning_text", text: "Detailed reasoning" }],
+            summary: [
+              { type: "summary_text", text: "Earlier reasoning summary" },
+            ],
+            encrypted_content: "opaque-reasoning-payload",
+          },
+        ],
+      }),
+      status: "completed",
+      created_at: 1000,
+      completed_at: 2000,
+      contract_snapshot_version: contractSnapshotVersion,
+    });
+
+    const agent = createFakeAgent({
+      responses: [
+        { type: "ai", id: "ai-2", content: "Second answer" },
+        { type: "ai", id: "ai-3", content: "Third answer" },
+      ],
+    });
+    const adapter = createOpenResponsesAdapter({
+      agent,
+      previousResponseStore: store,
+      generateId: (() => {
+        let counter = 0;
+        return () => `resp-reasoning-hop-${++counter}`;
+      })(),
+    });
+
+    const secondResponse = await adapter.invoke({
+      model: "gpt-4.1-mini",
+      previous_response_id: "resp-reasoning",
+      input: "Continue.",
+      metadata: {},
+      tools: [],
+      parallel_tool_calls: true,
+      stream: false,
+    });
+
+    await adapter.invoke({
+      model: "gpt-4.1-mini",
+      previous_response_id: secondResponse.id,
+      input: "Continue again.",
+      metadata: {},
+      tools: [],
+      parallel_tool_calls: true,
+      stream: false,
+    });
+
+    expect(agent.__getLastInvokeInput()?.messages).toEqual([
+      {
+        type: "system",
+        role: "system",
+        content: [{ type: "input_text", text: "Be terse." }],
+      },
+      {
+        type: "human",
+        role: "user",
+        content: "Tell me a joke",
+      },
+      {
+        type: "ai",
+        role: "assistant",
+        content: "Earlier reasoning summary",
+        additional_kwargs: {
+          reasoning: {
+            type: "reasoning",
+            id: "rs_123",
+            content: [{ type: "reasoning_text", text: "Detailed reasoning" }],
+            summary: [
+              { type: "summary_text", text: "Earlier reasoning summary" },
+            ],
+            encrypted_content: "opaque-reasoning-payload",
+          },
+        },
+      },
+      {
+        type: "human",
+        role: "user",
+        content: "Continue.",
+      },
+      {
+        type: "ai",
+        role: "assistant",
+        content: [
+          {
+            type: "output_text",
+            text: "Second answer",
+            annotations: [],
+            logprobs: [],
+          },
+        ],
+      },
+      {
+        type: "human",
+        role: "user",
+        content: "Continue again.",
+      },
+    ]);
+  });
+
   test("maps tool-call history input items to LangChain-compatible messages", async () => {
     const agent = createFakeAgent();
     const adapter = createOpenResponsesAdapter({ agent });

--- a/packages/openresponses-adapter/tests/unit/streaming.test.ts
+++ b/packages/openresponses-adapter/tests/unit/streaming.test.ts
@@ -655,7 +655,7 @@ describe("adapter.stream()", () => {
     expect(events.at(-1)).toBe("[DONE]");
   });
 
-  test("streaming persistence stores replay tool items separately from response output", async () => {
+  test("streaming persistence stores replay tool items and the full terminal response", async () => {
     const previousResponseStore = createInMemoryPreviousResponseStore();
     const adapter = createOpenResponsesAdapter({
       agent: createCallbackDrivenAgent({
@@ -669,6 +669,13 @@ describe("adapter.stream()", () => {
     const stream = await adapter.stream(baseRequest);
     const events = await collectStream(stream);
     const stored = await previousResponseStore.load(extractResponseId(events));
+    const completedEvent = events.find((event) => {
+      return typeof event !== "string" && event.type === "response.completed";
+    });
+
+    if (!completedEvent || typeof completedEvent === "string") {
+      throw new Error("Expected stream to emit response.completed");
+    }
 
     expect(stored?.request.input).toEqual([
       {
@@ -690,7 +697,7 @@ describe("adapter.stream()", () => {
         status: "completed",
       },
     ]);
-    expect(stored?.response.output).toEqual([]);
+    expect(stored?.response).toEqual(completedEvent.response);
   });
 
   test("multi-run callback sequences do not complete the response on sub-run completion", async () => {

--- a/packages/openresponses-adapter/tests/unit/streaming.test.ts
+++ b/packages/openresponses-adapter/tests/unit/streaming.test.ts
@@ -700,6 +700,68 @@ describe("adapter.stream()", () => {
     expect(stored?.response).toEqual(completedEvent.response);
   });
 
+  test("continuation from a streamed tool-call record does not duplicate tool items", async () => {
+    const previousResponseStore = createInMemoryPreviousResponseStore();
+    const streamingAdapter = createOpenResponsesAdapter({
+      agent: createCallbackDrivenAgent({
+        onStream: simulateToolCallStream,
+      }),
+      previousResponseStore,
+      clock: createDeterministicClock(1000),
+      generateId: createSequentialIdGenerator(["resp-1", "fc-1", "extra-1"]),
+    });
+
+    const events = await collectStream(await streamingAdapter.stream(baseRequest));
+    const responseId = extractResponseId(events);
+
+    const continuationAgent = createFakeAgent({
+      responses: [{ type: "ai", id: "ai-next", content: "Continued" }],
+    });
+    const continuationAdapter = createOpenResponsesAdapter({
+      agent: continuationAgent,
+      previousResponseStore,
+    });
+
+    await continuationAdapter.invoke({
+      ...baseRequest,
+      stream: false,
+      previous_response_id: responseId,
+      input: "Continue",
+    });
+
+    expect(continuationAgent.__getLastInvokeInput()?.messages).toEqual([
+      {
+        type: "human",
+        role: "user",
+        content: "Hello",
+      },
+      {
+        type: "ai",
+        role: "assistant",
+        content: [],
+        tool_calls: [
+          {
+            id: "call-1",
+            type: "tool_call",
+            name: "get_weather",
+            args: { city: "Boston" },
+          },
+        ],
+      },
+      {
+        type: "tool",
+        role: "tool",
+        tool_call_id: "call-1",
+        content: '{"temperature":"55F"}',
+      },
+      {
+        type: "human",
+        role: "user",
+        content: "Continue",
+      },
+    ]);
+  });
+
   test("multi-run callback sequences do not complete the response on sub-run completion", async () => {
     const adapter = createOpenResponsesAdapter({
       agent: createCallbackDrivenAgent({

--- a/packages/openresponses-adapter/tests/unit/streaming.test.ts
+++ b/packages/openresponses-adapter/tests/unit/streaming.test.ts
@@ -711,7 +711,9 @@ describe("adapter.stream()", () => {
       generateId: createSequentialIdGenerator(["resp-1", "fc-1", "extra-1"]),
     });
 
-    const events = await collectStream(await streamingAdapter.stream(baseRequest));
+    const events = await collectStream(
+      await streamingAdapter.stream(baseRequest)
+    );
     const responseId = extractResponseId(events);
 
     const continuationAgent = createFakeAgent({


### PR DESCRIPTION
## What changed

This PR fixes three issues in `packages/openresponses-adapter`:

- persisted streaming records now store the same terminal `ResponseResource` that clients receive on the stream
- `previous_response_id` continuation now preserves prior `reasoning` output as a reasoning payload instead of flattening it into plain assistant text
- release-facing and maintainer-facing docs now describe the package's current verified scope as pinned-snapshot JSON-surface conformance rather than implying closed full pinned-spec proof

## Why it changed

The streaming path was persisting a filtered terminal response that dropped `function_call` and `function_call_output` items, even though those items were still present in the streamed `response.completed` payload. That broke the package's own invariant that JSON responses, terminal SSE events, and stored continuation records should converge on the same public truth.

The continuation path also downgraded prior `reasoning` output items into plain assistant messages, which discarded structured reasoning state and `encrypted_content` during replay.

Separately, the docs had drifted into stronger compliance language than the maintained proof artifacts and public package metadata actually supported.

## Impact

- stored continuation records are now faithful to the streamed terminal response
- follow-up turns can preserve structured reasoning context more accurately
- the package claims are now consistent across the README, package metadata, and docs/

## Validation

- `bun run typecheck`
- `bun test`
- `bun run test:compliance:official`
- `bun run test:compliance:spec`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/skroyc/langchain-middlewares-callbacks-ts/pull/133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
