### PR TITLE
[adapter] extract the AG-UI adapter boundary and align package surfaces

### DIFF
--- a/packages/ag-ui-middleware-callbacks/CHANGELOG.md
+++ b/packages/ag-ui-middleware-callbacks/CHANGELOG.md
@@ -4,10 +4,14 @@
 
 ### Features
 
-- Froze the MVP backend/package contract in `docs/ContractFreeze.md`.
-- Added explicit public subpath entrypoints for `./callbacks` and
-  `./middleware`.
-- Switched package build output to ESM + CJS.
+- Added the reusable `./adapter` public subpath with `createAGUIAdapter(...)`
+  as the shared non-HTTP orchestration boundary.
+- Rebased `createAGUIBackend()` on top of the adapter boundary while preserving
+  strict request validation and one-event-per-frame SSE behavior.
+- Reworked the advanced custom-host example to reuse the shared adapter and
+  keep only auth, routing, and transport concerns in host code.
+- Updated package docs and example docs to reflect the adapter-first runtime
+  surface.
 
 ### Breaking Changes
 

--- a/packages/ag-ui-middleware-callbacks/README.md
+++ b/packages/ag-ui-middleware-callbacks/README.md
@@ -1,18 +1,21 @@
 # @skroyc/ag-ui-middleware-callbacks
 
-AG-UI backend and producer primitives for LangChain.js.
+AG-UI backend, adapter, and producer primitives for LangChain.js.
 
 ## Status
 
-The first contract-freeze epic is complete in docs. The frozen target package
-shape is recorded in [docs/ContractFreeze.md](./docs/ContractFreeze.md).
+The frozen MVP contract is recorded in
+[docs/ContractFreeze.md](./docs/ContractFreeze.md). The current shipped package
+now goes further and includes the extracted adapter boundary described in
+`docs/TechSpec.md`.
 
 Current implementation status:
 
-- published runtime surface: backend adapter, run-scoped publisher, and
-  low-level producers
+- published runtime surface: programmatic adapter, backend wrapper,
+  run-scoped publisher, and low-level producers
 - validated example set: CLI verifier plus GUI-backed default backend example
-  and advanced custom-host example under `example/`
+  and advanced custom-host example under `example/`, both reusing the same
+  adapter semantics
 - `createAGUIAgent`: still present in source for transition work, but no longer
   treated as public package API
 
@@ -28,6 +31,7 @@ Prefer explicit subpath imports:
 
 ```ts
 import { AGUICallbackHandler } from "@skroyc/ag-ui-middleware-callbacks/callbacks";
+import { createAGUIAdapter } from "@skroyc/ag-ui-middleware-callbacks/adapter";
 import { createAGUIBackend } from "@skroyc/ag-ui-middleware-callbacks/backend";
 import { createAGUIMiddleware } from "@skroyc/ag-ui-middleware-callbacks/middleware";
 import { createAGUIRunPublisher } from "@skroyc/ag-ui-middleware-callbacks/publication";
@@ -40,6 +44,31 @@ import {
 	AGUICallbackHandler,
 	createAGUIMiddleware,
 } from "@skroyc/ag-ui-middleware-callbacks";
+```
+
+## Programmatic Adapter Path
+
+Use the adapter subpath when your host wants to own auth, routing, or transport
+but still reuse the package's canonical run orchestration:
+
+```ts
+import { createAgent } from "langchain";
+import { createAGUIAdapter } from "@skroyc/ag-ui-middleware-callbacks/adapter";
+
+const adapter = createAGUIAdapter({
+  agentFactory: ({ input, middleware }) =>
+    createAgent({
+      model,
+      tools,
+      middleware: [middleware],
+    }),
+});
+
+const events = await adapter.stream(input, { signal });
+
+for await (const event of events) {
+  console.log(event);
+}
 ```
 
 ## Default Backend Path
@@ -65,7 +94,8 @@ export function handle(request: Request) {
 ```
 
 `handle(request)` expects a strict AG-UI `RunAgentInput` JSON payload and
-returns a streamed `text/event-stream` response.
+returns a streamed `text/event-stream` response. Internally, the backend now
+wraps `createAGUIAdapter()` rather than owning run orchestration itself.
 
 ## Low-Level Example
 
@@ -95,9 +125,13 @@ const callbacks = [
 
 - Reasoning events can be emitted as legacy `THINKING_*` or newer
   `REASONING_*` families.
+- New adapter-facing code should prefer `REASONING_*`; `THINKING_*` remains a
+  compatibility mode.
 - Thinking/reasoning content is derived from LangChain content blocks after the
   response is available; callback-only concurrent reasoning streaming is not
   currently possible.
 - The backend contract is `agentFactory({ input, middleware })`, not the older
   frozen `{ agent }` shape. This is intentional because LangChain middleware is
   attached at agent construction time.
+- Repo-level package builds should use
+  `bun run --filter @skroyc/ag-ui-middleware-callbacks build`.

--- a/packages/ag-ui-middleware-callbacks/docs/Architecture.md
+++ b/packages/ag-ui-middleware-callbacks/docs/Architecture.md
@@ -1,6 +1,7 @@
 # Solution Architecture
 
 ## 0. Version History & Changelog
+- v2.1.0 - Recorded the shipped adapter boundary after `createAGUIAdapter()`, backend wrapping, and custom-host reuse landed in code.
 - v2.0.0 - Rebuilt the logical architecture around the missing adapter boundary above middleware and callbacks, preserving brownfield continuity and clarifying the active convergence work.
 - v1.1.0 - Recorded the layered backend-adapter direction after publication and serving landed in the codebase.
 - v1.0.0 - Shifted the logical design away from a pure event-emitter mental model toward a backend-adapter architecture.
@@ -18,8 +19,8 @@
 
 ### Brownfield Starting Point
 - The current codebase already contains a default backend path, a run-scoped publisher, middleware and callback producers, examples, and a legacy `createAGUIAgent` compatibility surface.
-- The current codebase does not yet converge cleanly on one reusable adapter boundary. `createAGUIBackend()` owns HTTP serving and run orchestration together, while the advanced custom-host path duplicates much of the same orchestration logic in host code.
-- The planning artifacts currently mix historical target-state language with current-state implementation reality, which makes the architecture harder to trust than the code.
+- The current codebase now converges on one reusable adapter boundary. `createAGUIBackend()` wraps it for HTTP plus SSE, while the advanced custom-host path reuses the same orchestration and keeps only host concerns local.
+- The planning artifacts still mix historical target-state language with current-state implementation reality, which makes the architecture slightly harder to trust than the code until the remaining publication and verification epics are closed.
 
 ### Brownfield Rules Carried Forward
 - Middleware and callbacks remain producer surfaces only.

--- a/packages/ag-ui-middleware-callbacks/docs/ContractFreeze.md
+++ b/packages/ag-ui-middleware-callbacks/docs/ContractFreeze.md
@@ -1,5 +1,10 @@
 # Contract Freeze
 
+Historical note: this document freezes the earlier MVP target state. The
+current shipped package now also includes the `./adapter` subpath and backend
+rebasing work from Epic A. Use `README.md`, `docs/TechSpec.md`, and
+`docs/Tasks.md` for the up-to-date code state.
+
 This document is the authoritative outcome of the first epic in `docs/Tasks.md`
 (`P-1` through `P-3`).
 
@@ -114,7 +119,7 @@ These parts are worth reusing in later epics:
 
 ## Current-State Note
 
-This freeze is intentionally ahead of implementation. Until later epics land,
-the published package may expose only the existing low-level primitives. The
-backend/publication APIs defined here are the frozen target contract for the
-next implementation steps.
+This freeze intentionally captured the earlier target state ahead of
+implementation. The package has since moved beyond that point: backend,
+publication, and adapter surfaces are now implemented. Keep this document as
+historical context, not as the sole source of current behavior.

--- a/packages/ag-ui-middleware-callbacks/docs/Tasks.md
+++ b/packages/ag-ui-middleware-callbacks/docs/Tasks.md
@@ -1,33 +1,32 @@
 # Engineering Execution Plan
 
 ## 0. Version History & Changelog
+- v2.1.0 - Recorded Epic A as implemented and shifted the active critical path to publication hardening, legacy containment, and verification.
 - v2.0.0 - Rebased the plan around the remaining adapter-first convergence work and archived the earlier MVP backlog as brownfield context.
 - v1.1.0 - Recorded the MVP completion state after backend, publication, verification, and examples landed.
 - v1.0.0 - Planned the first backend-adapter implementation pass after the package moved beyond the original event-emitter framing.
 - ... [Older history truncated, refer to git logs]
 
 ## 1. Executive Summary & Active Critical Path
-- **Total Active Story Points:** 31
-- **Critical Path:** `AGA-A001 -> AGA-B001 -> AGA-B002 -> AGA-B003 -> AGA-D001`
+- **Total Active Story Points:** 21
+- **Critical Path:** `AGA-B001 -> AGA-B002 -> AGA-B003 -> AGA-D001`
 - **Planning Assumptions:** The package remains library-shaped, keeps LangChain as the execution engine, preserves the current backend behavior for consumers, and treats `createAGUIAgent` as a legacy compatibility surface rather than active product scope.
 
-The active delta is no longer "build a backend adapter from scratch." That work is already present in brownfield form. The remaining work is to converge the package on the correct adapter-first boundary so the default backend path, custom-host path, publication logic, compatibility surface, and verification story all point at the same architecture.
+The active delta is no longer "build a backend adapter from scratch." That work is now implemented in the package. The remaining work is to harden truthful publication, contain legacy compatibility, and rebuild release confidence around the converged adapter-first architecture.
 
 ### Brownfield Continuity Note
 - The package already contains a working backend path, a run-scoped publisher, producer layers, examples, and end-to-end tests.
-- The active plan does not reopen those completed foundations. It concentrates on extracting the reusable adapter boundary that the current code still keeps implicit, hardening truthful publication for the in-scope event families, and moving release confidence to the right public surfaces.
+- The active plan does not reopen those completed foundations. It now concentrates on hardening truthful publication for the in-scope event families and moving release confidence to the right public surfaces.
 - Historical work items from the earlier MVP backlog remain useful context and are preserved below as archived scope rather than active execution.
 
 ### Active Dependency Notes
-- **Adapter branch:** `AGA-A001` through `AGA-A003` establishes the reusable orchestration layer outside middleware and callbacks and removes duplicated host glue.
+- **Adapter branch:** `AGA-A001` through `AGA-A003` is implemented in the current codebase.
 - **Publication hardening branch:** `AGA-B001` through `AGA-B003` makes truthful publication policy explicit and closes the remaining reasoning and legacy-thinking edge cases.
 - **Compatibility branch:** `AGA-C001` through `AGA-C002` prevents the legacy `createAGUIAgent` path from continuing to define the package’s public identity.
 - **Verification branch:** `AGA-D001` is intentionally last because it should validate the converged product surfaces, not the transitional ones.
 
 ## 2. Project Phasing & Iteration Strategy
 ### Current Active Scope
-- Extract and publish a reusable adapter boundary above middleware and callbacks.
-- Make the default backend and custom-host paths reuse that adapter boundary instead of duplicating orchestration.
 - Encode and harden explicit truthful publication modes for the in-scope AG-UI event families, including legacy `THINKING_*` compatibility and modern `REASONING_*` behavior.
 - Move release confidence to the adapter-first public surfaces, examples, and built-package checks.
 - Contain `createAGUIAgent` as a legacy surface so it no longer drives the public mental model.
@@ -40,7 +39,8 @@ The active delta is no longer "build a backend adapter from scratch." That work 
 
 ### Archived or Already Completed Scope
 - Contract-freeze, publication core, default backend path, verification coverage, package alignment, README rewrite, and example replacement work from the earlier MVP backlog.
-- The completed MVP chain proved that the package could ship backend, publisher, and producer surfaces. It did not fully resolve the deeper architectural boundary issue around the missing adapter layer outside the hooks.
+- Adapter extraction, backend rebasing, and advanced custom-host convergence from Epic A.
+- The completed MVP chain proved that the package could ship backend, publisher, and producer surfaces. Epic A closed the deeper architectural boundary issue around the missing adapter layer outside the hooks.
 
 ### Archived MVP Ticket Families
 - `P-*`: package and serving contract freezing
@@ -72,9 +72,12 @@ flowchart LR
 ## 4. Ticket List
 ### Epic A — Adapter Boundary Extraction (AGA)
 
+Status: implemented in the current codebase on 2026-03-30.
+
 **AGA-A001 Introduce the reusable `createAGUIAdapter()` module**
 - **Type:** Feature
 - **Effort:** 5
+- **Status:** Implemented
 - **Dependencies:** None
 - **Legacy Issue ID:** S-2, D-2
 - **Capability / Contract Mapping:** AGC-001, AGC-002, AGC-006
@@ -91,6 +94,7 @@ And it yields canonical BaseEvent objects whose completion, error, and abort sem
 **AGA-A002 Rebase `createAGUIBackend()` on the adapter boundary**
 - **Type:** Feature
 - **Effort:** 3
+- **Status:** Implemented
 - **Dependencies:** AGA-A001
 - **Legacy Issue ID:** S-2, S-3
 - **Capability / Contract Mapping:** AGC-001, AGC-003
@@ -107,6 +111,7 @@ And the streamed public behavior remains compatible with the existing backend co
 **AGA-A003 Rework the advanced custom-host example to consume the adapter**
 - **Type:** Chore
 - **Effort:** 2
+- **Status:** Implemented
 - **Dependencies:** AGA-A001
 - **Legacy Issue ID:** D-2
 - **Capability / Contract Mapping:** AGC-002, AGC-006

--- a/packages/ag-ui-middleware-callbacks/docs/TechSpec.md
+++ b/packages/ag-ui-middleware-callbacks/docs/TechSpec.md
@@ -1,6 +1,7 @@
 # Technical Specification
 
 ## 0. Version History & Changelog
+- v2.1.0 - Recorded the shipped `./adapter` subpath, backend rebasing, and custom-host convergence after Epic A implementation.
 - v2.0.0 - Rebuilt the technical spec around an explicit adapter boundary above middleware and callbacks, recorded brownfield drift, and defined the remaining implementation contract for convergence.
 - v1.1.0 - Captured the MVP backend, publisher, and subpath export shape after the package moved beyond the original event-sink design.
 - v1.0.0 - Specified the initial backend-adapter contract after the package was re-scoped away from an `onEvent` bridge.
@@ -15,18 +16,18 @@
 - **Version Pinning / Compatibility Policy:** LangChain and AG-UI contracts are external integration units. Any contract-facing surface change must be checked against the installed `langchain` and `@ag-ui/core` versions in this workspace, not against memory or earlier docs. `createAGUIAgent` remains a brownfield compatibility surface, not the package’s public contract.
 
 ### 1.1 Brownfield Audit Summary
-- **Current package reality:** The package already exposes `./backend`, `./publication`, `./middleware`, and `./callbacks` subpaths, plus a working default backend path, examples, and a run-scoped single-writer publisher.
+- **Current package reality:** The package now exposes `./adapter`, `./backend`, `./publication`, `./middleware`, and `./callbacks` subpaths, plus a working default backend path, examples, and a run-scoped single-writer publisher.
 - **Current package reality:** The codebase still contains a legacy `createAGUIAgent` compatibility surface and tests that exercise it heavily, even though the documented public contract no longer centers it.
-- **Current package reality:** `createAGUIBackend()` currently combines HTTP serving concerns with the non-HTTP orchestration layer that custom hosts also need.
-- **Current package reality:** The advanced custom-host example duplicates backend orchestration logic, which is evidence that the reusable adapter boundary is still missing as a concrete module.
-- **Current package reality:** Planning artifacts still mix historical "target state" language with "already implemented" language. The code is ahead of the docs in some places and behind the intended architecture in others.
+- **Current package reality:** `createAGUIBackend()` now delegates non-HTTP orchestration to `createAGUIAdapter()` and stays focused on HTTP validation plus SSE response creation.
+- **Current package reality:** The advanced custom-host example now reuses the shared adapter boundary and only owns auth, routing, and transport response creation locally.
+- **Current package reality:** Planning artifacts still mix historical target-state language with already implemented work. The adapter extraction is done; the remaining convergence work is now publication hardening, compatibility containment, and release-quality verification.
 
 ### 1.2 Brownfield Drift Register
 | Area | Current Brownfield Reality | Target-State Requirement |
 | --- | --- | --- |
 | Product boundary | Public narrative still carries hook-first residue | Adapter boundary becomes the explicit product center |
-| Non-HTTP orchestration | `createAGUIBackend()` owns orchestration implicitly | A reusable programmatic adapter module owns it explicitly |
-| Custom hosts | Advanced example recreates orchestration manually | Custom hosts consume the same adapter boundary as the default backend |
+| Non-HTTP orchestration | `createAGUIAdapter()` now owns orchestration and `createAGUIBackend()` wraps it | Keep the adapter as the only non-HTTP orchestration path |
+| Custom hosts | Advanced example now consumes the shared adapter boundary | Keep custom hosts aligned with backend semantics instead of local glue |
 | Legacy compatibility | `createAGUIAgent` remains in source and tests | Compatibility surface becomes isolated and non-governing |
 | Truthful publication policy | Some degraded-fidelity rules exist only as code behavior | In-scope publication modes are recorded and tested explicitly |
 | Support artifacts | Main four planning docs are being updated, but older support docs remain historical | Governing artifacts must become trustworthy even when historical support docs remain in the repo |
@@ -75,8 +76,8 @@
 - **Consequences:** Verification must explicitly cover `./backend`, `./adapter`, and the advanced host path rather than only producer internals.
 
 ### Brownfield Drift Notes
-- `src/backend/create-agui-backend.ts` currently owns both HTTP handling and run orchestration.
-- The custom-host example currently reassembles the same orchestration with local helper code instead of consuming a shared adapter module.
+- `src/backend/create-agui-backend.ts` now owns HTTP handling and SSE response creation only.
+- The custom-host example now consumes the shared adapter module instead of reassembling runtime orchestration locally.
 - `src/index.ts` and some package comments still describe the package as producer-only even though the backend and publication surfaces already ship.
 - Main planning artifacts are being refreshed in this pass. Support artifacts such as `ContractFreeze.md` and `VerificationAudit.md` should be treated as historical context until intentionally updated.
 

--- a/packages/ag-ui-middleware-callbacks/docs/VerificationAudit.md
+++ b/packages/ag-ui-middleware-callbacks/docs/VerificationAudit.md
@@ -9,31 +9,26 @@ Audit date: 2026-03-13
 
 - LangChain middleware is attached when `createAgent(...)` is constructed, not
   injected later at `handle(request)` time.
+- The package now exposes a programmatic adapter surface that yields canonical
+  `BaseEvent` objects before transport framing.
 - AG-UI backend servers accept `RunAgentInput` and stream lifecycle/content
   events over SSE.
 
 These checks are consistent with the implemented `agentFactory({ input,
-middleware })` backend contract in source and README.
+middleware })` adapter and backend contracts in source and README.
 
 ## Requirement Traceability
 
 | Task | Acceptance criteria | Evidence | Status |
 |------|---------------------|----------|--------|
-| `Q-1` | `RUN_STARTED` appears before any text or tool event | `tests/unit/publication/create-agui-run-publisher.test.ts` buffers observation events until `RUN_STARTED` | Covered |
-| `Q-1` | Terminal completion or error behavior is deterministic | `tests/unit/publication/create-agui-run-publisher.test.ts` finalizes open streams before `RUN_FINISHED`, ignores post-terminal events, and exercises `close()` | Covered |
-| `Q-1` | Degraded-fidelity publication never fabricates deltas | `tests/unit/publication/create-agui-run-publisher.test.ts` allows final-only tool results without inventing tool lifecycle events | Covered |
-| `Q-2` | Concurrent runs do not share terminal state | `tests/unit/publication/create-agui-run-publisher.test.ts` isolates terminal state across concurrent publishers | Covered |
-| `Q-2` | Concurrent runs do not share producer state | `tests/unit/middleware/create-agui-middleware.test.ts` contains concurrency-isolation coverage for middleware run state | Covered |
-| `Q-3` | Valid HTTP request returns streamed SSE response | `tests/unit/backend/create-agui-backend.test.ts` returns SSE responses with canonical lifecycle events | Covered |
-| `Q-3` | Request parsing is strict | `tests/unit/backend/create-agui-backend.test.ts` rejects non-`POST`, non-JSON, and invalid `RunAgentInput` payloads before streaming | Covered |
-| `Q-3` | Event sequence is AG-UI-compatible | `tests/unit/backend/create-agui-backend.test.ts` verifies lifecycle order and one-event-per-frame SSE output | Covered |
-| `Q-3` | Disconnect and post-start failure behavior follows contract | `tests/unit/backend/create-agui-backend.test.ts` emits `RUN_ERROR` for post-start failures and closes aborted runs without inventing semantic events | Covered |
+| `AGA-A001` | Adapter yields canonical events without HTTP concerns | `tests/unit/adapter/create-agui-adapter.test.ts` covers lifecycle ordering, input mapping, post-start errors, and abort-safe closure | Covered |
+| `AGA-A002` | Backend remains a strict HTTP plus SSE wrapper over the adapter | `tests/unit/backend/create-agui-backend.test.ts` covers request validation, SSE framing, lifecycle order, and abort/error behavior | Covered |
+| `AGA-A003` | Advanced host reuses adapter semantics instead of local orchestration | `example/custom-host.ts` now delegates to `createAGUIAdapter(...)`, and `example/verify.ts` passes for both default and custom-host modes with `EXAMPLE_PROVIDER=mock` | Covered |
 
 ## Outcome
 
-- `Q-1` through `Q-3` are verified by the current test suite.
-- The only code gap found during this audit was missing explicit backend coverage
-  for unsupported non-JSON request bodies; that test is now present.
-- Planning/spec docs are aligned with the implemented
-  `agentFactory({ input, middleware })` backend shape, and the example surface
-  has been rebaselined onto the backend-adapter contract.
+- Epic A is verified by the current test suite plus the example verifiers.
+- The package now has one shared non-HTTP orchestration path for backend and
+  custom-host usage.
+- Remaining verification work is the future adapter-first release matrix
+  described in `AGA-D001`, not the adapter extraction itself.

--- a/packages/ag-ui-middleware-callbacks/example/README.md
+++ b/packages/ag-ui-middleware-callbacks/example/README.md
@@ -26,6 +26,9 @@ cd packages/ag-ui-middleware-callbacks/example
 
 bun install
 
+# Type-check the example workspace against the package declarations
+bun run typecheck
+
 # Verify the default backend contract from the CLI
 bun run verify
 
@@ -135,6 +138,10 @@ The custom-host verifier automatically sends the default auth token
   not to be a production UI.
 - The CLI is the primary contract check: it prints streamed events and fails if
   the lifecycle ordering is wrong.
+- The example `tsconfig.json` intentionally points at the package `dist/*.d.ts`
+  outputs. That keeps example type-checking aligned with the published surface,
+  but it means example type-checking requires a package build first; `bun run typecheck`
+  handles that for you.
 - If your shell auto-loads a live provider config from `.env`, override it with
   `EXAMPLE_PROVIDER=mock` when you want deterministic local verification.
 - The live probe is stricter about reasoning: if a provider does not surface

--- a/packages/ag-ui-middleware-callbacks/example/README.md
+++ b/packages/ag-ui-middleware-callbacks/example/README.md
@@ -7,8 +7,8 @@ This directory now mirrors the frozen backend-adapter package contract:
 - `server.ts`: default backend example using
   `createAGUIBackend(...).handle(request)`
 - `verify.ts`: CLI verifier that streams and validates the same backend handler
-- `custom-host.ts`: advanced host example using publisher + middleware +
-  callback primitives directly
+- `custom-host.ts`: advanced host example using `createAGUIAdapter(...)` plus
+  host-owned auth and SSE response wiring
 
 The examples intentionally avoid `createAGUIAgent` and internal `../src/*`
 imports in example code.
@@ -110,11 +110,12 @@ without depending on external rate limits.
 
 ## Advanced Custom Host Example
 
-- Uses `@skroyc/ag-ui-middleware-callbacks/publication`,
-  `/middleware`, and `/callbacks` directly
+- Uses `@skroyc/ag-ui-middleware-callbacks/adapter` directly
 - Demonstrates a host-owned concern outside the package: header auth via
   `x-example-key`
-- Keeps the run publisher as the single semantic writer
+- Reuses the same adapter config as the default backend example
+- Keeps transport ownership in the host example while delegating canonical run
+  orchestration to the shared adapter
 
 Start it with:
 
@@ -134,6 +135,8 @@ The custom-host verifier automatically sends the default auth token
   not to be a production UI.
 - The CLI is the primary contract check: it prints streamed events and fails if
   the lifecycle ordering is wrong.
+- If your shell auto-loads a live provider config from `.env`, override it with
+  `EXAMPLE_PROVIDER=mock` when you want deterministic local verification.
 - The live probe is stricter about reasoning: if a provider does not surface
   standardized LangChain `contentBlocks` for reasoning, the probe fails instead
   of silently falling back to provider-native payloads.

--- a/packages/ag-ui-middleware-callbacks/example/custom-host.ts
+++ b/packages/ag-ui-middleware-callbacks/example/custom-host.ts
@@ -1,44 +1,16 @@
-import { type BaseEvent, EventType } from "@ag-ui/core";
-import { createAgent } from "langchain";
-import {
-  AGUICallbackHandler,
-} from "@skroyc/ag-ui-middleware-callbacks/callbacks";
-import {
-  createAGUIMiddleware,
-} from "@skroyc/ag-ui-middleware-callbacks/middleware";
-import {
-  createAGUIRunPublisher,
-} from "@skroyc/ag-ui-middleware-callbacks/publication";
-import {
-  CUSTOM_HOST_HEADER,
-  DEFAULT_CUSTOM_HOST_TOKEN,
-} from "./config";
+import type { RunAgentInput } from "@ag-ui/core";
+import { createAGUIAdapter } from "@skroyc/ag-ui-middleware-callbacks/adapter";
+import { CUSTOM_HOST_HEADER, DEFAULT_CUSTOM_HOST_TOKEN } from "./config";
 import {
   acceptsJson,
-  consumeAgentStream,
-  createCalculatorTool,
-  createExampleModel,
+  createExampleAdapterConfig,
+  createSSEEventStream,
   createSSEHeaders,
-  isAbortError,
   jsonError,
   readRunInput,
-  resolveAgentConfig,
-  toAgentInput,
 } from "./runtime";
 
-const calculatorTool = createCalculatorTool();
-
-function publishFromMiddleware(
-  publisher: ReturnType<typeof createAGUIRunPublisher>
-): (event: BaseEvent) => void {
-  return (event) => {
-    if (event.type === EventType.RUN_FINISHED) {
-      return;
-    }
-
-    publisher.publish(event);
-  };
-}
+const adapter = createAGUIAdapter(createExampleAdapterConfig());
 
 function getAuthToken(): string {
   return Bun.env.EXAMPLE_AUTH_TOKEN ?? DEFAULT_CUSTOM_HOST_TOKEN;
@@ -59,7 +31,7 @@ export async function handleCustomHostRequest(
     return jsonError(415, "Unsupported Media Type");
   }
 
-  let input;
+  let input: RunAgentInput;
   try {
     input = await readRunInput(request);
   } catch (error) {
@@ -69,70 +41,13 @@ export async function handleCustomHostRequest(
     );
   }
 
-  const publisher = createAGUIRunPublisher({
-    validateEvents: true,
+  const events = await adapter.stream(input, {
+    signal: request.signal,
   });
 
-  const middleware = createAGUIMiddleware({
-    publish: publishFromMiddleware(publisher),
-    validateEvents: true,
-    emitActivities: true,
-    emitStateSnapshots: "initial",
-    errorDetailLevel: "message",
-    runIdOverride: input.runId,
-    threadIdOverride: input.threadId,
-  });
-
-  const callbackHandler = new AGUICallbackHandler({
-    publish: publisher.publish,
-    reasoningEventMode: "reasoning",
-  });
-
-  const response = new Response(publisher.toReadableStream(), {
+  return new Response(createSSEEventStream(events), {
     headers: createSSEHeaders(),
   });
-
-  (async () => {
-    try {
-      const agent = createAgent({
-        model: createExampleModel(resolveAgentConfig(input.forwardedProps)),
-        tools: [calculatorTool],
-        middleware: [middleware],
-      });
-
-      const stream = await agent.stream(toAgentInput(input), {
-        callbacks: [callbackHandler],
-        signal: request.signal,
-        streamMode: "values",
-        configurable: {
-          run_id: input.runId,
-          thread_id: input.threadId,
-        },
-        context: {
-          run_id: input.runId,
-          thread_id: input.threadId,
-          signal: request.signal,
-        },
-      });
-
-      const result = await consumeAgentStream(stream);
-      if (request.signal.aborted) {
-        publisher.close();
-      } else {
-        publisher.complete(result);
-      }
-    } catch (error) {
-      if (request.signal.aborted || isAbortError(error)) {
-        publisher.close();
-      } else {
-        publisher.error(error);
-      }
-    } finally {
-      callbackHandler.dispose();
-    }
-  })();
-
-  return response;
 }
 
 if (import.meta.main) {

--- a/packages/ag-ui-middleware-callbacks/example/package.json
+++ b/packages/ag-ui-middleware-callbacks/example/package.json
@@ -1,29 +1,30 @@
 {
-	"name": "ag-ui-middleware-callbacks-example",
-	"version": "0.0.1",
-	"type": "module",
-	"scripts": {
-		"dev": "bun --hot server.ts",
-		"start": "bun run server.ts",
-		"build": "bun build --target=bun server.ts custom-host.ts verify.ts verify-llmock.ts probe.ts capture-fixture.ts --outdir dist",
-		"capture-fixture": "bun run capture-fixture.ts",
-		"custom-host": "bun run custom-host.ts",
-		"verify": "bun run verify.ts default \"Calculate 2 + 2\"",
-		"verify:custom-host": "bun run verify.ts custom-host \"Calculate 2 + 2\"",
-		"verify:llmock": "bun run verify-llmock.ts",
-		"probe": "bun run probe.ts"
-	},
-	"dependencies": {
-		"@ag-ui/client": "^0.0.47",
-		"@ag-ui/core": "^0.0.47",
-		"@langchain/core": "^1.1.31",
-		"@langchain/openai": "^1.2.4",
-		"langchain": "^1.2.17",
-		"zod": "^4.3.6"
-	},
-	"devDependencies": {
-		"@copilotkit/llmock": "^1.3.1",
-		"bun-types": "^1.3.8",
-		"typescript": "^5.9.3"
-	}
+  "name": "ag-ui-middleware-callbacks-example",
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "bun --hot server.ts",
+    "start": "bun run server.ts",
+    "build": "bun build --target=bun server.ts custom-host.ts verify.ts verify-llmock.ts probe.ts capture-fixture.ts --outdir dist",
+    "typecheck": "bun run --cwd .. build && bunx tsc --noEmit -p tsconfig.json",
+    "capture-fixture": "bun run capture-fixture.ts",
+    "custom-host": "bun run custom-host.ts",
+    "verify": "bun run verify.ts default \"Calculate 2 + 2\"",
+    "verify:custom-host": "bun run verify.ts custom-host \"Calculate 2 + 2\"",
+    "verify:llmock": "bun run verify-llmock.ts",
+    "probe": "bun run probe.ts"
+  },
+  "dependencies": {
+    "@ag-ui/client": "^0.0.47",
+    "@ag-ui/core": "^0.0.47",
+    "@langchain/core": "^1.1.31",
+    "@langchain/openai": "^1.2.4",
+    "langchain": "^1.2.17",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@copilotkit/llmock": "^1.3.1",
+    "bun-types": "^1.3.8",
+    "typescript": "^5.9.3"
+  }
 }

--- a/packages/ag-ui-middleware-callbacks/example/probe.ts
+++ b/packages/ag-ui-middleware-callbacks/example/probe.ts
@@ -2,7 +2,11 @@
 
 import { HumanMessage } from "@langchain/core/messages";
 import { createExampleModel } from "./runtime";
-import { envConfig, printVerificationResult, runExampleVerification } from "./verification";
+import {
+  envConfig,
+  printVerificationResult,
+  runExampleVerification,
+} from "./verification";
 
 type VerifyMode = "default" | "custom-host";
 
@@ -95,12 +99,14 @@ console.log(
 console.log("");
 
 for await (const chunk of stream) {
-  const chunkRecord = isRecord(chunk) ? chunk : {};
+  const chunkRecord = isRecord(chunk) ? chunk : undefined;
+  const content = chunkRecord?.content;
+  const contentBlocks = chunkRecord?.contentBlocks;
   const token =
-    readString(chunkRecord.content) ??
-    (Array.isArray(chunkRecord.content) ? JSON.stringify(chunkRecord.content) : "");
-  const blocks = Array.isArray(chunkRecord.contentBlocks)
-    ? chunkRecord.contentBlocks
+    readString(content) ??
+    (Array.isArray(content) ? JSON.stringify(content) : "");
+  const blocks = Array.isArray(contentBlocks)
+    ? contentBlocks
         .map(summarizeContentBlock)
         .filter((block): block is ContentBlockSummary => block !== null)
         .filter((block) => block.preview.length > 0 || block.type.length > 0)
@@ -111,7 +117,10 @@ for await (const chunk of stream) {
     continue;
   }
 
-  if (firstReasoningChunk < 0 && blocks.some((block) => block.type === "reasoning")) {
+  if (
+    firstReasoningChunk < 0 &&
+    blocks.some((block) => block.type === "reasoning")
+  ) {
     firstReasoningChunk = chunkIndex;
   }
 

--- a/packages/ag-ui-middleware-callbacks/example/runtime.ts
+++ b/packages/ag-ui-middleware-callbacks/example/runtime.ts
@@ -17,7 +17,7 @@ import type {
   AGUIAdapterConfig,
   AGUIAgentLike,
 } from "@skroyc/ag-ui-middleware-callbacks/adapter";
-import { serializeEventAsSSE } from "@skroyc/ag-ui-middleware-callbacks/publication";
+import { createSSEStream } from "@skroyc/ag-ui-middleware-callbacks/publication";
 import { createAgent, tool } from "langchain";
 import { z } from "zod";
 import {
@@ -433,19 +433,7 @@ export function createSSEHeaders(): Headers {
 export function createSSEEventStream(
   events: AsyncIterable<BaseEvent>
 ): ReadableStream<Uint8Array> {
-  return new ReadableStream<Uint8Array>({
-    async start(controller) {
-      try {
-        for await (const event of events) {
-          controller.enqueue(serializeEventAsSSE(event));
-        }
-
-        controller.close();
-      } catch (error) {
-        controller.error(error);
-      }
-    },
-  });
+  return createSSEStream(events);
 }
 
 export function buildRunAgentInput(

--- a/packages/ag-ui-middleware-callbacks/example/runtime.ts
+++ b/packages/ag-ui-middleware-callbacks/example/runtime.ts
@@ -7,18 +7,24 @@ import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import {
   AIMessage,
   AIMessageChunk,
-  HumanMessage,
   type BaseMessage,
+  HumanMessage,
   ToolMessage,
 } from "@langchain/core/messages";
+import type { ChatGenerationChunk, ChatResult } from "@langchain/core/outputs";
 import { ChatOpenAI } from "@langchain/openai";
-import { tool } from "langchain";
+import type {
+  AGUIAdapterConfig,
+  AGUIAgentLike,
+} from "@skroyc/ag-ui-middleware-callbacks/adapter";
+import { serializeEventAsSSE } from "@skroyc/ag-ui-middleware-callbacks/publication";
+import { createAgent, tool } from "langchain";
 import { z } from "zod";
 import {
   CALCULATOR_TOOL_PARAMETERS,
+  DEFAULT_AGENT_CONFIG,
   type ExampleAgentConfig,
   type ExampleProvider,
-  DEFAULT_AGENT_CONFIG,
 } from "./config";
 
 const SSE_HEADERS = {
@@ -29,15 +35,6 @@ const SSE_HEADERS = {
 
 const ARITHMETIC_EXPRESSION_REGEX =
   /(-?\d+(?:\.\d+)?)\s*([+\-*/])\s*(-?\d+(?:\.\d+)?)/;
-
-interface GeneratedResponse {
-  generations: Array<{
-    text: unknown;
-    message: AIMessage;
-    generationInfo: Record<string, unknown>;
-  }>;
-  llmOutput: Record<string, unknown>;
-}
 
 interface ArithmeticOperation {
   a: number;
@@ -54,7 +51,9 @@ function isRunAgentInput(value: unknown): value is RunAgentInput {
   return result.success;
 }
 
-function mapOperatorToOperation(operator: string): ArithmeticOperation["operation"] {
+function mapOperatorToOperation(
+  operator: string
+): ArithmeticOperation["operation"] {
   switch (operator) {
     case "+":
       return "add";
@@ -75,17 +74,27 @@ function parseArithmeticOperation(input: string): ArithmeticOperation | null {
     return null;
   }
 
+  const left = match[1];
+  const operator = match[2];
+  const right = match[3];
+  if (!(left && operator && right)) {
+    return null;
+  }
+
   return {
-    a: Number(match[1]),
-    b: Number(match[3]),
-    operation: mapOperatorToOperation(match[2]),
+    a: Number(left),
+    b: Number(right),
+    operation: mapOperatorToOperation(operator),
   };
 }
 
 function getLastUserMessage(messages: BaseMessage[]): string {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
-    if (message instanceof HumanMessage && typeof message.content === "string") {
+    if (
+      message instanceof HumanMessage &&
+      typeof message.content === "string"
+    ) {
       return message.content;
     }
   }
@@ -94,26 +103,24 @@ function getLastUserMessage(messages: BaseMessage[]): string {
 }
 
 class ExampleMockModel extends BaseChatModel {
-  private boundTools: unknown[] = [];
-
   constructor() {
     super({
-      temperature: 0,
       callbacks: undefined,
       tags: undefined,
       metadata: undefined,
     });
   }
 
-  override bindTools(tools: unknown[]): ExampleMockModel {
+  override bindTools(_tools: unknown[]): ExampleMockModel {
     const bound = new ExampleMockModel();
-    bound.boundTools = tools;
     return bound;
   }
 
-  protected _generate(
-    messages: BaseMessage[]
-  ): Promise<GeneratedResponse> {
+  _generate(
+    messages: BaseMessage[],
+    _options: Record<string, unknown>,
+    _runManager?: unknown
+  ): Promise<ChatResult> {
     const response = this.createResponse(messages);
     return Promise.resolve({
       generations: [
@@ -128,16 +135,16 @@ class ExampleMockModel extends BaseChatModel {
   }
 
   override async *_streamResponseChunks(
-    messages: BaseMessage[]
-  ): AsyncGenerator<{
-    message: AIMessageChunk;
-    generationInfo: Record<string, unknown>;
-  }> {
+    messages: BaseMessage[],
+    _options: Record<string, unknown>,
+    _runManager?: unknown
+  ): AsyncGenerator<ChatGenerationChunk> {
     const response = this.createResponse(messages);
     await Promise.resolve();
 
     if (Array.isArray(response.tool_calls) && response.tool_calls.length > 0) {
       yield {
+        text: "",
         message: new AIMessageChunk({
           content: "",
           tool_call_chunks: response.tool_calls.map((toolCall, index) => ({
@@ -145,26 +152,28 @@ class ExampleMockModel extends BaseChatModel {
             name: toolCall.name,
             args: JSON.stringify(toolCall.args),
             index,
-            type: "tool_call",
+            type: "tool_call_chunk" as const,
           })),
           additional_kwargs: {},
           response_metadata: {},
-        } as ConstructorParameters<typeof AIMessageChunk>[0]),
+        }),
         generationInfo: {},
-      };
+      } as ChatGenerationChunk;
       return;
     }
 
-    const content = typeof response.content === "string" ? response.content : "";
+    const content =
+      typeof response.content === "string" ? response.content : "";
     for (const chunk of content) {
       yield {
+        text: chunk,
         message: new AIMessageChunk({
           content: chunk,
           additional_kwargs: {},
           response_metadata: {},
         }),
         generationInfo: {},
-      };
+      } as ChatGenerationChunk;
     }
   }
 
@@ -215,7 +224,9 @@ class ExampleMockModel extends BaseChatModel {
   }
 }
 
-export function resolveAgentConfig(forwardedProps: unknown): ExampleAgentConfig {
+export function resolveAgentConfig(
+  forwardedProps: unknown
+): ExampleAgentConfig {
   if (!isRecord(forwardedProps)) {
     return DEFAULT_AGENT_CONFIG;
   }
@@ -244,13 +255,16 @@ export function resolveAgentConfig(forwardedProps: unknown): ExampleAgentConfig 
         ? forwardedProps.useResponsesApi
         : DEFAULT_AGENT_CONFIG.useResponsesApi,
     outputVersion:
-      forwardedProps.outputVersion === "v1" ? "v1" : DEFAULT_AGENT_CONFIG.outputVersion,
+      forwardedProps.outputVersion === "v1"
+        ? "v1"
+        : DEFAULT_AGENT_CONFIG.outputVersion,
   };
 }
 
 function usesResponsesApiOutput(model: string): boolean {
   const normalizedModel = model.trim().toLowerCase();
-  const providerQualifiedModel = normalizedModel.split("/").at(-1) ?? normalizedModel;
+  const providerQualifiedModel =
+    normalizedModel.split("/").at(-1) ?? normalizedModel;
   return providerQualifiedModel.startsWith("gpt-5");
 }
 
@@ -285,7 +299,7 @@ export function createExampleModel(config: ExampleAgentConfig): BaseChatModel {
 
 export function createCalculatorTool() {
   return tool(
-    async ({
+    ({
       a,
       b,
       operation,
@@ -303,6 +317,8 @@ export function createCalculatorTool() {
           return String(a * b);
         case "divide":
           return String(a / b);
+        default:
+          throw new Error(`Unsupported operation: ${operation}`);
       }
     },
     {
@@ -322,6 +338,32 @@ export function createAGUIToolDefinition() {
     name: "calculator",
     description: "Perform arithmetic operations.",
     parameters: CALCULATOR_TOOL_PARAMETERS,
+  };
+}
+
+const calculatorTool = createCalculatorTool();
+type CreateAgentConfig = Parameters<typeof createAgent>[0];
+type LangChainMiddlewareEntry = NonNullable<
+  CreateAgentConfig["middleware"]
+>[number];
+
+export function createExampleAdapterConfig(): AGUIAdapterConfig {
+  return {
+    validateEvents: true,
+    emitActivities: true,
+    emitStateSnapshots: "initial",
+    callbackOptions: {
+      reasoningEventMode: "reasoning",
+    },
+    agentFactory: ({
+      input,
+      middleware,
+    }: Parameters<NonNullable<AGUIAdapterConfig["agentFactory"]>>[0]) =>
+      createAgent({
+        model: createExampleModel(resolveAgentConfig(input.forwardedProps)),
+        tools: [calculatorTool],
+        middleware: [middleware as unknown as LangChainMiddlewareEntry],
+      }) as unknown as AGUIAgentLike,
   };
 }
 
@@ -386,6 +428,24 @@ export async function consumeAgentStream(
 
 export function createSSEHeaders(): Headers {
   return new Headers(SSE_HEADERS);
+}
+
+export function createSSEEventStream(
+  events: AsyncIterable<BaseEvent>
+): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        for await (const event of events) {
+          controller.enqueue(serializeEventAsSSE(event));
+        }
+
+        controller.close();
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+  });
 }
 
 export function buildRunAgentInput(

--- a/packages/ag-ui-middleware-callbacks/example/server.ts
+++ b/packages/ag-ui-middleware-callbacks/example/server.ts
@@ -1,32 +1,12 @@
-import { createAgent } from "langchain";
-import index from "./index.html";
 import {
-  createAGUIBackend,
   type AGUIBackend,
+  createAGUIBackend,
 } from "@skroyc/ag-ui-middleware-callbacks/backend";
-import {
-  createCalculatorTool,
-  createExampleModel,
-  resolveAgentConfig,
-} from "./runtime";
-
-const calculatorTool = createCalculatorTool();
+import index from "./index.html";
+import { createExampleAdapterConfig } from "./runtime";
 
 export function createExampleBackend(): AGUIBackend {
-  return createAGUIBackend({
-    validateEvents: true,
-    emitActivities: true,
-    emitStateSnapshots: "initial",
-    callbackOptions: {
-      reasoningEventMode: "reasoning",
-    },
-    agentFactory: ({ input, middleware }) =>
-      createAgent({
-        model: createExampleModel(resolveAgentConfig(input.forwardedProps)),
-        tools: [calculatorTool],
-        middleware: [middleware],
-      }),
-  });
+  return createAGUIBackend(createExampleAdapterConfig());
 }
 
 const backend = createExampleBackend();

--- a/packages/ag-ui-middleware-callbacks/example/tsconfig.json
+++ b/packages/ag-ui-middleware-callbacks/example/tsconfig.json
@@ -1,25 +1,32 @@
 {
-	"compilerOptions": {
-		"target": "ES2022",
-		"module": "ESNext",
-		"moduleResolution": "bundler",
-		"strict": true,
-		"skipLibCheck": true,
-		"forceConsistentCasingInFileNames": true,
-		"noEmit": true,
-		"resolveJsonModule": true,
-		"allowSyntheticDefaultImports": true,
-		"types": ["bun-types"],
-		"lib": ["ES2022", "DOM"],
-		"baseUrl": ".",
-		"paths": {
-			"@skroyc/ag-ui-middleware-callbacks": ["../src/index.ts"],
-			"@skroyc/ag-ui-middleware-callbacks/backend": ["../src/backend.ts"],
-			"@skroyc/ag-ui-middleware-callbacks/callbacks": ["../src/callbacks.ts"],
-			"@skroyc/ag-ui-middleware-callbacks/middleware": ["../src/middleware.ts"],
-			"@skroyc/ag-ui-middleware-callbacks/publication": ["../src/publication.ts"]
-		}
-	},
-	"include": ["*.ts"],
-	"exclude": ["node_modules", "dist"]
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["bun-types"],
+    "lib": ["ES2022", "DOM"],
+    "baseUrl": ".",
+    "paths": {
+      "@skroyc/ag-ui-middleware-callbacks": ["../dist/index.d.ts"],
+      "@skroyc/ag-ui-middleware-callbacks/adapter": ["../dist/adapter.d.ts"],
+      "@skroyc/ag-ui-middleware-callbacks/backend": ["../dist/backend.d.ts"],
+      "@skroyc/ag-ui-middleware-callbacks/callbacks": [
+        "../dist/callbacks.d.ts"
+      ],
+      "@skroyc/ag-ui-middleware-callbacks/middleware": [
+        "../dist/middleware.d.ts"
+      ],
+      "@skroyc/ag-ui-middleware-callbacks/publication": [
+        "../dist/publication.d.ts"
+      ]
+    }
+  },
+  "include": ["*.ts"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/ag-ui-middleware-callbacks/example/verification.ts
+++ b/packages/ag-ui-middleware-callbacks/example/verification.ts
@@ -1,4 +1,4 @@
-import { type BaseEvent, EventSchemas } from "@ag-ui/core";
+import { type BaseEvent, EventSchemas, EventType } from "@ag-ui/core";
 import {
   CUSTOM_HOST_HEADER,
   DEFAULT_AGENT_CONFIG,
@@ -41,6 +41,11 @@ export interface VerificationResult {
   frames: string[];
   events: BaseEvent[];
   audit: VerificationAudit;
+}
+
+function readStringField(event: BaseEvent, field: string): string | undefined {
+  const value = (event as Record<string, unknown>)[field];
+  return typeof value === "string" ? value : undefined;
 }
 
 export function envConfig(): ExampleAgentConfig {
@@ -100,14 +105,71 @@ function validateEvents(events: BaseEvent[]): ValidationIssue[] {
         index,
         type: event.type,
         issues: result.error.issues.map(
-          (issue) =>
-            `${issue.path.join(".") || "<root>"}: ${issue.message}`
+          (issue) => `${issue.path.join(".") || "<root>"}: ${issue.message}`
         ),
       });
     }
   }
 
   return issues;
+}
+
+function markMessageLifecycle(
+  event: BaseEvent,
+  messageHasContent: Map<string, boolean>,
+  messageHasEnd: Map<string, boolean>
+): boolean {
+  const messageId = readStringField(event, "messageId");
+  if (!messageId) {
+    return false;
+  }
+
+  if (event.type === EventType.TEXT_MESSAGE_START) {
+    messageHasContent.set(messageId, false);
+    messageHasEnd.set(messageId, false);
+    return true;
+  }
+
+  if (event.type === EventType.TEXT_MESSAGE_CONTENT) {
+    messageHasContent.set(messageId, true);
+    return true;
+  }
+
+  if (event.type === EventType.TEXT_MESSAGE_END) {
+    messageHasEnd.set(messageId, true);
+    return true;
+  }
+
+  return false;
+}
+
+function markToolLifecycle(
+  event: BaseEvent,
+  toolCallHasArgs: Map<string, boolean>,
+  toolCallHasEnd: Map<string, boolean>
+): boolean {
+  const toolCallId = readStringField(event, "toolCallId");
+  if (!toolCallId) {
+    return false;
+  }
+
+  if (event.type === EventType.TOOL_CALL_START) {
+    toolCallHasArgs.set(toolCallId, false);
+    toolCallHasEnd.set(toolCallId, false);
+    return true;
+  }
+
+  if (event.type === EventType.TOOL_CALL_ARGS) {
+    toolCallHasArgs.set(toolCallId, true);
+    return true;
+  }
+
+  if (event.type === EventType.TOOL_CALL_END) {
+    toolCallHasEnd.set(toolCallId, true);
+    return true;
+  }
+
+  return false;
 }
 
 function auditEvents(events: BaseEvent[]): VerificationAudit {
@@ -118,50 +180,31 @@ function auditEvents(events: BaseEvent[]): VerificationAudit {
   const eventTypes = events.map((event) => event.type);
 
   for (const event of events) {
-    if (event.type === "TEXT_MESSAGE_START") {
-      messageHasContent.set(event.messageId, false);
-      messageHasEnd.set(event.messageId, false);
+    if (markMessageLifecycle(event, messageHasContent, messageHasEnd)) {
       continue;
     }
 
-    if (event.type === "TEXT_MESSAGE_CONTENT") {
-      messageHasContent.set(event.messageId, true);
-      continue;
-    }
-
-    if (event.type === "TEXT_MESSAGE_END") {
-      messageHasEnd.set(event.messageId, true);
-      continue;
-    }
-
-    if (event.type === "TOOL_CALL_START") {
-      toolCallHasArgs.set(event.toolCallId, false);
-      toolCallHasEnd.set(event.toolCallId, false);
-      continue;
-    }
-
-    if (event.type === "TOOL_CALL_ARGS") {
-      toolCallHasArgs.set(event.toolCallId, true);
-      continue;
-    }
-
-    if (event.type === "TOOL_CALL_END") {
-      toolCallHasEnd.set(event.toolCallId, true);
-    }
+    markToolLifecycle(event, toolCallHasArgs, toolCallHasEnd);
   }
 
   return {
     emptyAssistantMessages: [...messageHasContent.entries()]
-      .filter(([messageId, hasContent]) => hasContent === false && messageHasEnd.get(messageId))
+      .filter(
+        ([messageId, hasContent]) =>
+          hasContent === false && messageHasEnd.get(messageId)
+      )
       .map(([messageId]) => messageId),
     toolCallsWithoutArgs: [...toolCallHasArgs.entries()]
-      .filter(([toolCallId, hasArgs]) => hasArgs === false && toolCallHasEnd.get(toolCallId))
+      .filter(
+        ([toolCallId, hasArgs]) =>
+          hasArgs === false && toolCallHasEnd.get(toolCallId)
+      )
       .map(([toolCallId]) => toolCallId),
     reasoningStartsAfterTextMessages:
-      eventTypes.includes("REASONING_START") &&
-      eventTypes.includes("TEXT_MESSAGE_START") &&
-      eventTypes.indexOf("REASONING_START") >
-        eventTypes.indexOf("TEXT_MESSAGE_START"),
+      eventTypes.includes(EventType.REASONING_START) &&
+      eventTypes.includes(EventType.TEXT_MESSAGE_START) &&
+      eventTypes.indexOf(EventType.REASONING_START) >
+        eventTypes.indexOf(EventType.TEXT_MESSAGE_START),
     invalidEvents: validateEvents(events),
   };
 }
@@ -210,8 +253,7 @@ export function assertVerificationResult(
   if (result.audit.invalidEvents.length > 0) {
     const detail = result.audit.invalidEvents
       .map(
-        (issue) =>
-          `#${issue.index} ${issue.type}: ${issue.issues.join("; ")}`
+        (issue) => `#${issue.index} ${issue.type}: ${issue.issues.join("; ")}`
       )
       .join("\n");
     throw new Error(`Invalid AG-UI events detected:\n${detail}`);

--- a/packages/ag-ui-middleware-callbacks/example/verify-llmock.ts
+++ b/packages/ag-ui-middleware-callbacks/example/verify-llmock.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 
-import { type BaseEvent, EventSchemas } from "@ag-ui/core";
+import { type BaseEvent, EventSchemas, EventType } from "@ag-ui/core";
 import {
   CUSTOM_HOST_HEADER,
   DEFAULT_CUSTOM_HOST_TOKEN,
@@ -24,6 +24,11 @@ interface VerificationResult {
   prompt: string;
   frames: string[];
   events: BaseEvent[];
+}
+
+function readStringField(event: BaseEvent, field: string): string | undefined {
+  const value = (event as Record<string, unknown>)[field];
+  return typeof value === "string" ? value : undefined;
 }
 
 function printUsage(): void {
@@ -61,26 +66,33 @@ function assertNoEmptyAssistantMessages(events: BaseEvent[]): void {
   const contentCounts = new Map<string, number>();
 
   for (const event of events) {
-    if (event.type === "TEXT_MESSAGE_START") {
-      started.add(event.messageId);
+    if (event.type === EventType.TEXT_MESSAGE_START) {
+      const messageId = readStringField(event, "messageId");
+      if (messageId) {
+        started.add(messageId);
+      }
       continue;
     }
 
-    if (event.type === "TEXT_MESSAGE_CONTENT") {
-      contentCounts.set(
-        event.messageId,
-        (contentCounts.get(event.messageId) ?? 0) + 1
-      );
+    if (event.type === EventType.TEXT_MESSAGE_CONTENT) {
+      const messageId = readStringField(event, "messageId");
+      if (messageId) {
+        contentCounts.set(messageId, (contentCounts.get(messageId) ?? 0) + 1);
+      }
       continue;
     }
 
-    if (event.type === "TEXT_MESSAGE_END") {
-      ended.add(event.messageId);
+    if (event.type === EventType.TEXT_MESSAGE_END) {
+      const messageId = readStringField(event, "messageId");
+      if (messageId) {
+        ended.add(messageId);
+      }
     }
   }
 
   const emptyMessages = [...started].filter(
-    (messageId) => ended.has(messageId) && (contentCounts.get(messageId) ?? 0) === 0
+    (messageId) =>
+      ended.has(messageId) && (contentCounts.get(messageId) ?? 0) === 0
   );
 
   if (emptyMessages.length > 0) {
@@ -91,21 +103,32 @@ function assertNoEmptyAssistantMessages(events: BaseEvent[]): void {
 }
 
 function assertToolLifecycle(events: BaseEvent[]): void {
-  const toolStarts = events.filter((event) => event.type === "TOOL_CALL_START");
+  const toolStarts = events.filter(
+    (event) => event.type === EventType.TOOL_CALL_START
+  );
   const toolArgs = new Set(
     events
-      .filter((event) => event.type === "TOOL_CALL_ARGS")
-      .map((event) => event.toolCallId)
+      .filter((event) => event.type === EventType.TOOL_CALL_ARGS)
+      .map((event) => readStringField(event, "toolCallId"))
+      .filter(
+        (toolCallId): toolCallId is string => typeof toolCallId === "string"
+      )
   );
   const toolEnds = new Set(
     events
-      .filter((event) => event.type === "TOOL_CALL_END")
-      .map((event) => event.toolCallId)
+      .filter((event) => event.type === EventType.TOOL_CALL_END)
+      .map((event) => readStringField(event, "toolCallId"))
+      .filter(
+        (toolCallId): toolCallId is string => typeof toolCallId === "string"
+      )
   );
   const toolResults = new Set(
     events
-      .filter((event) => event.type === "TOOL_CALL_RESULT")
-      .map((event) => event.toolCallId)
+      .filter((event) => event.type === EventType.TOOL_CALL_RESULT)
+      .map((event) => readStringField(event, "toolCallId"))
+      .filter(
+        (toolCallId): toolCallId is string => typeof toolCallId === "string"
+      )
   );
 
   if (toolStarts.length === 0) {
@@ -113,22 +136,21 @@ function assertToolLifecycle(events: BaseEvent[]): void {
   }
 
   for (const event of toolStarts) {
-    if (!toolArgs.has(event.toolCallId)) {
-      throw new Error(
-        `Missing TOOL_CALL_ARGS for toolCallId ${event.toolCallId}.`
-      );
+    const toolCallId = readStringField(event, "toolCallId");
+    if (!toolCallId) {
+      throw new Error("Observed TOOL_CALL_START without a string toolCallId.");
     }
 
-    if (!toolEnds.has(event.toolCallId)) {
-      throw new Error(
-        `Missing TOOL_CALL_END for toolCallId ${event.toolCallId}.`
-      );
+    if (!toolArgs.has(toolCallId)) {
+      throw new Error(`Missing TOOL_CALL_ARGS for toolCallId ${toolCallId}.`);
     }
 
-    if (!toolResults.has(event.toolCallId)) {
-      throw new Error(
-        `Missing TOOL_CALL_RESULT for toolCallId ${event.toolCallId}.`
-      );
+    if (!toolEnds.has(toolCallId)) {
+      throw new Error(`Missing TOOL_CALL_END for toolCallId ${toolCallId}.`);
+    }
+
+    if (!toolResults.has(toolCallId)) {
+      throw new Error(`Missing TOOL_CALL_RESULT for toolCallId ${toolCallId}.`);
     }
   }
 }
@@ -161,7 +183,9 @@ async function runScenario(
       : await handleChatRequest(request);
 
   if (!response.ok) {
-    throw new Error(`Unexpected status ${response.status}: ${await response.text()}`);
+    throw new Error(
+      `Unexpected status ${response.status}: ${await response.text()}`
+    );
   }
 
   const frames = await readSSEFrames(response);
@@ -189,9 +213,17 @@ async function run(): Promise<void> {
 
   try {
     const results = [
-      await runScenario("default", "Say hello in one short sentence.", llmock.config),
+      await runScenario(
+        "default",
+        "Say hello in one short sentence.",
+        llmock.config
+      ),
       await runScenario("default", "Calculate 2 + 2", llmock.config),
-      await runScenario("custom-host", "Say hello in one short sentence.", llmock.config),
+      await runScenario(
+        "custom-host",
+        "Say hello in one short sentence.",
+        llmock.config
+      ),
       await runScenario("custom-host", "Calculate 2 + 2", llmock.config),
     ];
 
@@ -201,7 +233,9 @@ async function run(): Promise<void> {
       }
 
       console.log(`[${result.mode}] ${result.prompt}`);
-      console.log(`Frames: ${result.frames.length} Events: ${result.events.length}`);
+      console.log(
+        `Frames: ${result.frames.length} Events: ${result.events.length}`
+      );
       for (const event of result.events) {
         console.log(`  ${summarizeEvent(event)}`);
       }

--- a/packages/ag-ui-middleware-callbacks/package.json
+++ b/packages/ag-ui-middleware-callbacks/package.json
@@ -1,82 +1,87 @@
 {
-	"name": "@skroyc/ag-ui-middleware-callbacks",
-	"version": "1.1.1",
-	"description": "LangChain.js integration providing middleware and callbacks for AG-UI protocol compatibility",
-	"type": "module",
-	"sideEffects": false,
-	"keywords": [
-		"langchain",
-		"ag-ui",
-		"middleware",
-		"callbacks",
-		"agent",
-		"streaming"
-	],
-	"author": "SkrOYC <oscar@ocmasesorias.com>",
-	"license": "MIT",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/skrOYC/langchain-middlewares-callbacks-ts.git",
-		"directory": "packages/ag-ui-middleware-callbacks"
-	},
-	"engines": {
-		"node": ">=20.0.0"
-	},
-	"files": [
-		"dist/",
-		"package.json",
-		"README.md",
-		"LICENSE"
-	],
-	"main": "./dist/index.cjs",
-	"module": "./dist/index.js",
-	"types": "./dist/index.d.ts",
-	"exports": {
-		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js",
-			"require": "./dist/index.cjs"
-		},
-		"./callbacks": {
-			"types": "./dist/callbacks.d.ts",
-			"import": "./dist/callbacks.js",
-			"require": "./dist/callbacks.cjs"
-		},
-		"./middleware": {
-			"types": "./dist/middleware.d.ts",
-			"import": "./dist/middleware.js",
-			"require": "./dist/middleware.cjs"
-		},
-		"./publication": {
-			"types": "./dist/publication.d.ts",
-			"import": "./dist/publication.js",
-			"require": "./dist/publication.cjs"
-		},
-		"./backend": {
-			"types": "./dist/backend.d.ts",
-			"import": "./dist/backend.js",
-			"require": "./dist/backend.cjs"
-		}
-	},
-	"peerDependencies": {
-		"langchain": "catalog:peer",
-		"typescript": "catalog:peer"
-	},
-	"peerDependenciesMeta": {
-		"langchain": {
-			"optional": false
-		}
-	},
-	"dependencies": {
-		"@ag-ui/core": "^0.0.47",
-		"@langchain/core": "catalog:",
-		"fast-json-patch": "^3.1.1",
-		"zod": "catalog:"
-	},
-	"devDependencies": {},
-	"scripts": {
-		"build": "tsup",
-		"test": "bun test",
-		"lint": "bunx --bun @biomejs/biome check src tests"
-	}
+  "name": "@skroyc/ag-ui-middleware-callbacks",
+  "version": "1.1.1",
+  "description": "AG-UI backend, adapter, and producer primitives for LangChain.js",
+  "type": "module",
+  "sideEffects": false,
+  "keywords": [
+    "langchain",
+    "ag-ui",
+    "middleware",
+    "callbacks",
+    "agent",
+    "streaming"
+  ],
+  "author": "SkrOYC <oscar@ocmasesorias.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/skrOYC/langchain-middlewares-callbacks-ts.git",
+    "directory": "packages/ag-ui-middleware-callbacks"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "files": [
+    "dist/",
+    "package.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./callbacks": {
+      "types": "./dist/callbacks.d.ts",
+      "import": "./dist/callbacks.js",
+      "require": "./dist/callbacks.cjs"
+    },
+    "./adapter": {
+      "types": "./dist/adapter.d.ts",
+      "import": "./dist/adapter.js",
+      "require": "./dist/adapter.cjs"
+    },
+    "./middleware": {
+      "types": "./dist/middleware.d.ts",
+      "import": "./dist/middleware.js",
+      "require": "./dist/middleware.cjs"
+    },
+    "./publication": {
+      "types": "./dist/publication.d.ts",
+      "import": "./dist/publication.js",
+      "require": "./dist/publication.cjs"
+    },
+    "./backend": {
+      "types": "./dist/backend.d.ts",
+      "import": "./dist/backend.js",
+      "require": "./dist/backend.cjs"
+    }
+  },
+  "peerDependencies": {
+    "langchain": "catalog:peer",
+    "typescript": "catalog:peer"
+  },
+  "peerDependenciesMeta": {
+    "langchain": {
+      "optional": false
+    }
+  },
+  "dependencies": {
+    "@ag-ui/core": "^0.0.47",
+    "@langchain/core": "catalog:",
+    "fast-json-patch": "^3.1.1",
+    "zod": "catalog:"
+  },
+  "devDependencies": {},
+  "scripts": {
+    "build": "tsup",
+    "test": "bun test",
+    "lint": "bunx --bun @biomejs/biome check src tests"
+  }
 }

--- a/packages/ag-ui-middleware-callbacks/src/adapter.ts
+++ b/packages/ag-ui-middleware-callbacks/src/adapter.ts
@@ -1,0 +1,20 @@
+import {
+  type AGUIAdapterConfig as AGUIAdapterConfigImplementation,
+  type AGUIAdapter as AGUIAdapterImplementation,
+  type AGUIAdapterRunOptions as AGUIAdapterRunOptionsImplementation,
+  type AGUIAgentFactory as AGUIAgentFactoryImplementation,
+  type AGUIAgentLike as AGUIAgentLikeImplementation,
+  type AGUIAgentRunOptions as AGUIAgentRunOptionsImplementation,
+  createAGUIAdapter as createAGUIAdapterImplementation,
+} from "@/adapter/create-agui-adapter";
+
+export type AGUIAdapter = AGUIAdapterImplementation;
+export type AGUIAdapterConfig = AGUIAdapterConfigImplementation;
+export type AGUIAdapterRunOptions = AGUIAdapterRunOptionsImplementation;
+export type AGUIAgentFactory = AGUIAgentFactoryImplementation;
+export type AGUIAgentLike = AGUIAgentLikeImplementation;
+export type AGUIAgentRunOptions = AGUIAgentRunOptionsImplementation;
+
+export function createAGUIAdapter(config: AGUIAdapterConfig): AGUIAdapter {
+  return createAGUIAdapterImplementation(config);
+}

--- a/packages/ag-ui-middleware-callbacks/src/adapter/create-agui-adapter.ts
+++ b/packages/ag-ui-middleware-callbacks/src/adapter/create-agui-adapter.ts
@@ -111,6 +111,7 @@ function createAsyncQueue<T>(): {
   const waiters: QueueWaiter<T>[] = [];
   let isClosed = false;
   let failure: unknown;
+  let hasConsumer = false;
 
   const resolveBufferedValues = () => {
     while (values.length > 0 && waiters.length > 0) {
@@ -183,6 +184,14 @@ function createAsyncQueue<T>(): {
 
     iterable: {
       async *[Symbol.asyncIterator]() {
+        if (hasConsumer) {
+          throw new Error(
+            "AGUI adapter event streams support a single consumer."
+          );
+        }
+
+        hasConsumer = true;
+
         while (true) {
           if (values.length > 0) {
             yield values.shift() as T;
@@ -276,8 +285,21 @@ export function createAGUIAdapter(config: AGUIAdapterConfig): AGUIAdapter {
             publisher.error(error);
           }
         } finally {
-          callbackHandler.dispose();
-          unsubscribe();
+          try {
+            callbackHandler.dispose();
+          } catch (error) {
+            console.error("Failed to dispose AG-UI callback handler.", error);
+          }
+
+          try {
+            unsubscribe();
+          } catch (error) {
+            console.error(
+              "Failed to unsubscribe AG-UI adapter listener.",
+              error
+            );
+          }
+
           eventQueue.close();
         }
       })();

--- a/packages/ag-ui-middleware-callbacks/src/adapter/create-agui-adapter.ts
+++ b/packages/ag-ui-middleware-callbacks/src/adapter/create-agui-adapter.ts
@@ -1,0 +1,292 @@
+import { type BaseEvent, EventType, type RunAgentInput } from "@ag-ui/core";
+import {
+  AGUICallbackHandler,
+  type AGUICallbackHandlerOptions,
+} from "@/callbacks/agui-callback-handler";
+import { createAGUIMiddleware } from "@/middleware/create-agui-middleware";
+import type { AGUIMiddlewareOptions } from "@/middleware/types";
+import { createAGUIRunPublisher } from "@/publication/create-agui-run-publisher";
+
+export interface AGUIAgentRunOptions extends Record<string, unknown> {
+  callbacks?: unknown[];
+  configurable?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  signal?: AbortSignal;
+  streamMode?: unknown;
+}
+
+export interface AGUIAgentLike {
+  stream(
+    input: Record<string, unknown>,
+    options?: AGUIAgentRunOptions
+  ): Promise<AsyncIterable<unknown>>;
+}
+
+export type AGUIAgentFactory = (args: {
+  input: RunAgentInput;
+  middleware: ReturnType<typeof createAGUIMiddleware>;
+}) => AGUIAgentLike | Promise<AGUIAgentLike>;
+
+export interface AGUIAdapterRunOptions {
+  signal?: AbortSignal;
+}
+
+export interface AGUIAdapter {
+  stream(
+    input: RunAgentInput,
+    options?: AGUIAdapterRunOptions
+  ): Promise<AsyncIterable<BaseEvent>>;
+}
+
+export interface AGUIAdapterConfig {
+  agentFactory: AGUIAgentFactory;
+  validateEvents?: boolean | "strict";
+  emitStateSnapshots?: AGUIMiddlewareOptions["emitStateSnapshots"];
+  emitActivities?: AGUIMiddlewareOptions["emitActivities"];
+  errorDetailLevel?: AGUIMiddlewareOptions["errorDetailLevel"];
+  callbackOptions?: Omit<AGUICallbackHandlerOptions, "publish">;
+}
+
+interface QueueWaiter<T> {
+  reject: (reason?: unknown) => void;
+  resolve: (result: IteratorResult<T>) => void;
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof DOMException && error.name === "AbortError") ||
+    (error instanceof Error && error.name === "AbortError")
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toAgentInput(input: RunAgentInput): Record<string, unknown> {
+  if (isRecord(input.state)) {
+    return {
+      ...input.state,
+      messages: input.messages,
+    };
+  }
+
+  return {
+    messages: input.messages,
+    state: input.state,
+  };
+}
+
+function publishFromMiddleware(
+  publisher: ReturnType<typeof createAGUIRunPublisher>
+): (event: BaseEvent) => void {
+  return (event) => {
+    if (event.type === EventType.RUN_FINISHED) {
+      return;
+    }
+
+    publisher.publish(event);
+  };
+}
+
+async function consumeAgentStream(
+  stream: AsyncIterable<unknown>
+): Promise<unknown> {
+  let lastChunk: unknown;
+
+  for await (const chunk of stream) {
+    lastChunk = chunk;
+  }
+
+  return lastChunk;
+}
+
+function createAsyncQueue<T>(): {
+  close: () => void;
+  error: (error: unknown) => void;
+  iterable: AsyncIterable<T>;
+  push: (value: T) => void;
+} {
+  const values: T[] = [];
+  const waiters: QueueWaiter<T>[] = [];
+  let isClosed = false;
+  let failure: unknown;
+
+  const resolveBufferedValues = () => {
+    while (values.length > 0 && waiters.length > 0) {
+      const waiter = waiters.shift();
+      const value = values.shift();
+      if (waiter && typeof value !== "undefined") {
+        waiter.resolve({ value, done: false });
+      }
+    }
+  };
+
+  const rejectPendingWaiters = () => {
+    if (typeof failure === "undefined") {
+      return;
+    }
+
+    for (const waiter of waiters.splice(0)) {
+      waiter.reject(failure);
+    }
+  };
+
+  const closePendingWaiters = () => {
+    if (!isClosed) {
+      return;
+    }
+
+    for (const waiter of waiters.splice(0)) {
+      waiter.resolve({ value: undefined as T, done: true });
+    }
+  };
+
+  const flush = () => {
+    resolveBufferedValues();
+
+    if (values.length > 0 || waiters.length === 0) {
+      return;
+    }
+
+    rejectPendingWaiters();
+    closePendingWaiters();
+  };
+
+  return {
+    push(value) {
+      if (isClosed || typeof failure !== "undefined") {
+        return;
+      }
+
+      values.push(value);
+      flush();
+    },
+
+    close() {
+      if (isClosed || typeof failure !== "undefined") {
+        return;
+      }
+
+      isClosed = true;
+      flush();
+    },
+
+    error(error) {
+      if (isClosed || typeof failure !== "undefined") {
+        return;
+      }
+
+      failure = error;
+      flush();
+    },
+
+    iterable: {
+      async *[Symbol.asyncIterator]() {
+        while (true) {
+          if (values.length > 0) {
+            yield values.shift() as T;
+            continue;
+          }
+
+          if (typeof failure !== "undefined") {
+            throw failure;
+          }
+
+          if (isClosed) {
+            return;
+          }
+
+          const result = await new Promise<IteratorResult<T>>(
+            (resolve, reject) => {
+              waiters.push({ resolve, reject });
+            }
+          );
+
+          if (result.done) {
+            return;
+          }
+
+          yield result.value;
+        }
+      },
+    },
+  };
+}
+
+export function createAGUIAdapter(config: AGUIAdapterConfig): AGUIAdapter {
+  if (typeof config.agentFactory !== "function") {
+    throw new TypeError(
+      "agentFactory must be a function that accepts { input, middleware } and returns an agent with a stream() method"
+    );
+  }
+
+  return {
+    stream(input, options = {}) {
+      const publisher = createAGUIRunPublisher({
+        validateEvents: config.validateEvents,
+      });
+      const eventQueue = createAsyncQueue<BaseEvent>();
+      const unsubscribe = publisher.subscribe((event) => {
+        eventQueue.push(event);
+      });
+
+      const callbackHandler = new AGUICallbackHandler({
+        publish: publisher.publish,
+        ...config.callbackOptions,
+      });
+      const middleware = createAGUIMiddleware({
+        publish: publishFromMiddleware(publisher),
+        validateEvents: config.validateEvents ?? false,
+        emitStateSnapshots: config.emitStateSnapshots ?? "initial",
+        emitActivities: config.emitActivities ?? false,
+        errorDetailLevel: config.errorDetailLevel ?? "message",
+        runIdOverride: input.runId,
+        threadIdOverride: input.threadId,
+      });
+
+      const run = (async () => {
+        try {
+          const agent = await config.agentFactory({ input, middleware });
+          const stream = await agent.stream(toAgentInput(input), {
+            callbacks: [callbackHandler],
+            signal: options.signal,
+            streamMode: "values",
+            configurable: {
+              run_id: input.runId,
+              thread_id: input.threadId,
+            },
+            context: {
+              run_id: input.runId,
+              thread_id: input.threadId,
+              signal: options.signal,
+            },
+          });
+
+          const result = await consumeAgentStream(stream);
+          if (options.signal?.aborted) {
+            publisher.close();
+          } else {
+            publisher.complete(result);
+          }
+        } catch (error) {
+          if (options.signal?.aborted || isAbortError(error)) {
+            publisher.close();
+          } else {
+            publisher.error(error);
+          }
+        } finally {
+          callbackHandler.dispose();
+          unsubscribe();
+          eventQueue.close();
+        }
+      })();
+
+      run.catch((error) => {
+        eventQueue.error(error);
+      });
+
+      return Promise.resolve(eventQueue.iterable);
+    },
+  };
+}

--- a/packages/ag-ui-middleware-callbacks/src/backend/create-agui-backend.ts
+++ b/packages/ag-ui-middleware-callbacks/src/backend/create-agui-backend.ts
@@ -1,50 +1,22 @@
+import type { RunAgentInput } from "@ag-ui/core";
+import { RunAgentInputSchema } from "@ag-ui/core";
 import {
-  type BaseEvent,
-  EventType,
-  type RunAgentInput,
-  RunAgentInputSchema,
-} from "@ag-ui/core";
-import {
-  AGUICallbackHandler,
-  type AGUICallbackHandlerOptions,
-} from "@/callbacks/agui-callback-handler";
-import { createAGUIMiddleware } from "@/middleware/create-agui-middleware";
-import type { AGUIMiddlewareOptions } from "@/middleware/types";
-import { createAGUIRunPublisher } from "@/publication/create-agui-run-publisher";
-import { createSSEResponse } from "@/transports/sse";
+  type AGUIAdapterConfig,
+  type AGUIAgentLike,
+  type AGUIAgentRunOptions,
+  createAGUIAdapter,
+} from "@/adapter/create-agui-adapter";
+import { createSSEResponse, createSSEStream } from "@/transports/sse";
+
+export type { AGUIAgentFactory } from "@/adapter/create-agui-adapter";
 
 export interface AGUIBackend {
   handle(request: Request): Promise<Response>;
 }
 
-export interface AGUIBackendRunOptions extends Record<string, unknown> {
-  callbacks?: unknown[];
-  configurable?: Record<string, unknown>;
-  context?: Record<string, unknown>;
-  signal?: AbortSignal;
-  streamMode?: unknown;
-}
-
-export interface AGUIBackendAgentLike {
-  stream(
-    input: Record<string, unknown>,
-    options?: AGUIBackendRunOptions
-  ): Promise<AsyncIterable<unknown>>;
-}
-
-export type AGUIAgentFactory = (args: {
-  input: RunAgentInput;
-  middleware: ReturnType<typeof createAGUIMiddleware>;
-}) => AGUIBackendAgentLike | Promise<AGUIBackendAgentLike>;
-
-export interface AGUIBackendConfig {
-  agentFactory: AGUIAgentFactory;
-  validateEvents?: boolean | "strict";
-  emitStateSnapshots?: AGUIMiddlewareOptions["emitStateSnapshots"];
-  emitActivities?: AGUIMiddlewareOptions["emitActivities"];
-  errorDetailLevel?: AGUIMiddlewareOptions["errorDetailLevel"];
-  callbackOptions?: Omit<AGUICallbackHandlerOptions, "publish">;
-}
+export type AGUIBackendRunOptions = AGUIAgentRunOptions;
+export type AGUIBackendAgentLike = AGUIAgentLike;
+export type AGUIBackendConfig = AGUIAdapterConfig;
 
 function jsonError(status: number, error: string): Response {
   return new Response(JSON.stringify({ error }), {
@@ -60,66 +32,13 @@ function acceptsJson(request: Request): boolean {
   return contentType?.toLowerCase().includes("application/json") ?? false;
 }
 
-function isAbortError(error: unknown): boolean {
-  return (
-    (error instanceof DOMException && error.name === "AbortError") ||
-    (error instanceof Error && error.name === "AbortError")
-  );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function toAgentInput(input: RunAgentInput): Record<string, unknown> {
-  if (isRecord(input.state)) {
-    return {
-      ...input.state,
-      messages: input.messages,
-    };
-  }
-
-  return {
-    messages: input.messages,
-    state: input.state,
-  };
-}
-
-function publishFromMiddleware(
-  publisher: ReturnType<typeof createAGUIRunPublisher>
-): (event: BaseEvent) => void {
-  return (event) => {
-    if (event.type === EventType.RUN_FINISHED) {
-      return;
-    }
-
-    publisher.publish(event);
-  };
-}
-
 async function readRunInput(request: Request): Promise<RunAgentInput> {
   const payload = await request.json();
   return RunAgentInputSchema.parse(payload);
 }
 
-async function consumeAgentStream(
-  stream: AsyncIterable<unknown>
-): Promise<unknown> {
-  let lastChunk: unknown;
-
-  for await (const chunk of stream) {
-    lastChunk = chunk;
-  }
-
-  return lastChunk;
-}
-
 export function createAGUIBackend(config: AGUIBackendConfig): AGUIBackend {
-  if (typeof config.agentFactory !== "function") {
-    throw new TypeError(
-      "agentFactory must be a function that accepts { input, middleware } and returns an agent with a stream() method"
-    );
-  }
+  const adapter = createAGUIAdapter(config);
 
   return {
     async handle(request) {
@@ -147,63 +66,11 @@ export function createAGUIBackend(config: AGUIBackendConfig): AGUIBackend {
         );
       }
 
-      const publisher = createAGUIRunPublisher({
-        validateEvents: config.validateEvents,
-      });
-      const middlewarePublish = publishFromMiddleware(publisher);
-      const middleware = createAGUIMiddleware({
-        publish: middlewarePublish,
-        validateEvents: config.validateEvents ?? false,
-        emitStateSnapshots: config.emitStateSnapshots ?? "initial",
-        emitActivities: config.emitActivities ?? false,
-        errorDetailLevel: config.errorDetailLevel ?? "message",
-        runIdOverride: input.runId,
-        threadIdOverride: input.threadId,
+      const events = await adapter.stream(input, {
+        signal: request.signal,
       });
 
-      const response = createSSEResponse(publisher.toReadableStream());
-
-      (async () => {
-        const callbackHandler = new AGUICallbackHandler({
-          publish: publisher.publish,
-          ...config.callbackOptions,
-        });
-
-        try {
-          const agent = await config.agentFactory({ input, middleware });
-          const stream = await agent.stream(toAgentInput(input), {
-            callbacks: [callbackHandler],
-            signal: request.signal,
-            streamMode: "values",
-            configurable: {
-              run_id: input.runId,
-              thread_id: input.threadId,
-            },
-            context: {
-              run_id: input.runId,
-              thread_id: input.threadId,
-              signal: request.signal,
-            },
-          });
-
-          const result = await consumeAgentStream(stream);
-          if (request.signal.aborted) {
-            publisher.close();
-          } else {
-            publisher.complete(result);
-          }
-        } catch (error) {
-          if (request.signal.aborted || isAbortError(error)) {
-            publisher.close();
-          } else {
-            publisher.error(error);
-          }
-        } finally {
-          callbackHandler.dispose();
-        }
-      })();
-
-      return response;
+      return createSSEResponse(createSSEStream(events));
     },
   };
 }

--- a/packages/ag-ui-middleware-callbacks/src/create-agui-agent.ts
+++ b/packages/ag-ui-middleware-callbacks/src/create-agui-agent.ts
@@ -107,7 +107,7 @@ function withInjectedAGUICallback(
   // Runtime callback list provided. Avoid duplicates if AG-UI callback already exists.
   if (Array.isArray(callbacks)) {
     if (callbacks.some(isAGUICallbackHandler)) {
-      return runtimeOptions;
+      return runtimeOptions ?? {};
     }
     return {
       ...runtimeOptions,
@@ -116,7 +116,7 @@ function withInjectedAGUICallback(
   }
 
   // Non-array callback manager provided: honor runtime callbacks as source of truth.
-  return runtimeOptions;
+  return runtimeOptions ?? {};
 }
 
 function wrapAgentWithPerRunAGUICallback(

--- a/packages/ag-ui-middleware-callbacks/src/index.ts
+++ b/packages/ag-ui-middleware-callbacks/src/index.ts
@@ -1,12 +1,11 @@
 /**
- * AG-UI low-level producer exports for LangChain.js.
+ * Minimal root exports for the AG-UI LangChain package.
  *
- * The first contract-freeze epic keeps the published runtime surface honest:
- * this root entry currently exposes only the existing low-level producer APIs.
- * The frozen backend-adapter contract lives in `docs/ContractFreeze.md` and
- * will be implemented in later epics.
+ * The package now ships adapter-first public subpaths such as `./adapter`,
+ * `./backend`, and `./publication`, but the root entry stays intentionally
+ * small and keeps exposing only the low-level producer primitives.
  *
- * Package scope today: producer primitives only.
+ * Use explicit subpath imports for builder-facing integration surfaces.
  *
  * @packageDocumentation
  */

--- a/packages/ag-ui-middleware-callbacks/src/publication.ts
+++ b/packages/ag-ui-middleware-callbacks/src/publication.ts
@@ -7,6 +7,7 @@ import {
 } from "./publication/create-agui-run-publisher";
 import {
   type AGUIEventSerializer,
+  createSSEStream as createSSEStreamImplementation,
   serializeEventAsSSE as serializeEventAsSSEImplementation,
 } from "./publication/serializer";
 
@@ -24,4 +25,10 @@ export function createAGUIRunPublisher(
 
 export function serializeEventAsSSE(event: Parameters<AGUIEventSerializer>[0]) {
   return serializeEventAsSSEImplementation(event);
+}
+
+export function createSSEStream(
+  events: AsyncIterable<Parameters<AGUIEventSerializer>[0]>
+) {
+  return createSSEStreamImplementation(events);
 }

--- a/packages/ag-ui-middleware-callbacks/src/publication/serializer.ts
+++ b/packages/ag-ui-middleware-callbacks/src/publication/serializer.ts
@@ -1,7 +1,11 @@
 import type { BaseEvent } from "@ag-ui/core";
-import { serializeEventAsSSE as serializeEventAsSSEImplementation } from "@/transports/sse";
+import {
+  createSSEStream as createSSEStreamImplementation,
+  serializeEventAsSSE as serializeEventAsSSEImplementation,
+} from "@/transports/sse";
 
 export type AGUIEventSerializer = (event: BaseEvent) => Uint8Array;
+export const createSSEStream = createSSEStreamImplementation;
 export const serializeEventAsSSE = serializeEventAsSSEImplementation;
 
 export function resolvePublisherSerializer(

--- a/packages/ag-ui-middleware-callbacks/src/transports/sse.ts
+++ b/packages/ag-ui-middleware-callbacks/src/transports/sse.ts
@@ -15,6 +15,24 @@ export function serializeEventAsSSE(event: BaseEvent): Uint8Array {
   return textEncoder.encode(`data: ${JSON.stringify(event)}\n\n`);
 }
 
+export function createSSEStream(
+  events: AsyncIterable<BaseEvent>
+): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        for await (const event of events) {
+          controller.enqueue(serializeEventAsSSE(event));
+        }
+
+        controller.close();
+      } catch (error) {
+        controller.error(error);
+      }
+    },
+  });
+}
+
 export function createSSEResponse(
   stream: ReadableStream<Uint8Array>,
   init: ResponseInit = {}

--- a/packages/ag-ui-middleware-callbacks/src/utils/message-mapper.ts
+++ b/packages/ag-ui-middleware-callbacks/src/utils/message-mapper.ts
@@ -249,11 +249,15 @@ export function mapLangChainMessageToAGUI(message: BaseMessage): Message {
   }
 
   if (role === "tool") {
+    if (!toolCallId) {
+      throw new Error("Cannot map a tool-role message without a toolCallId.");
+    }
+
     const toolMessage: AGUIToolMessage = {
       id,
       role,
       content: fallbackStringContent(messageLike.content),
-      toolCallId: toolCallId ?? generateId(),
+      toolCallId,
     };
     return toolMessage;
   }

--- a/packages/ag-ui-middleware-callbacks/src/utils/message-mapper.ts
+++ b/packages/ag-ui-middleware-callbacks/src/utils/message-mapper.ts
@@ -1,4 +1,15 @@
-import type { Message, Role, ToolCall } from "@ag-ui/core";
+import type {
+  SystemMessage as AGUISystemMessage,
+  ToolMessage as AGUIToolMessage,
+  AssistantMessage,
+  DeveloperMessage,
+  InputContent,
+  Message,
+  ReasoningMessage,
+  Role,
+  ToolCall,
+  UserMessage,
+} from "@ag-ui/core";
 import {
   AIMessage,
   type BaseMessage,
@@ -12,21 +23,6 @@ import { generateId } from "./id-generator";
 const UNSERIALIZABLE_CONTENT_FALLBACK = "[unserializable content]";
 const UNSERIALIZABLE_TOOL_ARGS_FALLBACK = "{}";
 
-interface AGUITextInputContent {
-  type: "text";
-  text: string;
-}
-
-interface AGUIBinaryInputContent {
-  type: "binary";
-  mimeType: string;
-  id?: string;
-  url?: string;
-  data?: string;
-  filename?: string;
-}
-
-type AGUIInputContent = AGUITextInputContent | AGUIBinaryInputContent;
 interface ToolCallSource {
   id?: string;
   name?: unknown;
@@ -62,6 +58,9 @@ function fallbackStringContent(value: unknown): string {
   if (typeof value === "undefined") {
     return "";
   }
+  if (typeof value === "string") {
+    return value;
+  }
   const serialized = safeStringify(value);
   if (typeof serialized === "string") {
     return serialized;
@@ -69,7 +68,9 @@ function fallbackStringContent(value: unknown): string {
   return UNSERIALIZABLE_CONTENT_FALLBACK;
 }
 
-function isAGUITextInputContent(value: unknown): value is AGUITextInputContent {
+function isAGUITextInputContent(
+  value: unknown
+): value is Extract<InputContent, { type: "text" }> {
   if (!isRecord(value)) {
     return false;
   }
@@ -78,7 +79,7 @@ function isAGUITextInputContent(value: unknown): value is AGUITextInputContent {
 
 function isAGUIBinaryInputContent(
   value: unknown
-): value is AGUIBinaryInputContent {
+): value is Extract<InputContent, { type: "binary" }> {
   if (!isRecord(value)) {
     return false;
   }
@@ -102,7 +103,7 @@ function isAGUIBinaryInputContent(
   );
 }
 
-function isAGUIInputContentArray(value: unknown): value is AGUIInputContent[] {
+function isAGUIInputContentArray(value: unknown): value is InputContent[] {
   if (!Array.isArray(value)) {
     return false;
   }
@@ -111,14 +112,14 @@ function isAGUIInputContentArray(value: unknown): value is AGUIInputContent[] {
   );
 }
 
-function toRole(value: unknown): Role | undefined {
+function toRole(value: unknown): Exclude<Role, "activity"> | undefined {
   switch (value) {
     case "assistant":
     case "user":
     case "system":
     case "developer":
     case "tool":
-    case "activity":
+    case "reasoning":
       return value;
     default:
       return undefined;
@@ -128,7 +129,7 @@ function toRole(value: unknown): Role | undefined {
 function mapContentForRole(
   role: Role,
   content: unknown
-): string | AGUIInputContent[] | undefined {
+): string | InputContent[] {
   if (typeof content === "string") {
     return content;
   }
@@ -141,33 +142,33 @@ function mapContentForRole(
   return fallbackStringContent(content);
 }
 
-/**
- * Maps a LangChain BaseMessage to an AG-UI Protocol Message.
- *
- * @param message - The LangChain message to map
- * @returns An AG-UI Protocol compliant Message object
- */
-export function mapLangChainMessageToAGUI(message: BaseMessage): Message {
-  const messageLike = message as MessageLike;
-  const id = messageLike.id || generateId();
-  let role: Role = "assistant";
-  let toolCalls: ToolCall[] | undefined;
-  let toolCallId: string | undefined;
+function resolveRoleAndToolState(
+  message: BaseMessage,
+  messageLike: MessageLike
+): {
+  role: Exclude<Role, "activity">;
+  toolCallId?: string;
+  toolCalls?: ToolCall[];
+} {
   const messageType = messageLike._getType?.();
   const explicitRole = toRole(messageLike.role);
+  let role: Exclude<Role, "activity"> = "assistant";
+  let toolCalls: ToolCall[] | undefined;
+  let toolCallId: string | undefined;
 
   if (
     message instanceof HumanMessage ||
     explicitRole === "user" ||
     messageType === "human"
   ) {
-    role = "user";
-  } else if (
+    return { role: "user" };
+  }
+
+  if (
     message instanceof AIMessage ||
     explicitRole === "assistant" ||
     messageType === "ai"
   ) {
-    role = "assistant";
     const toolCallsFromLLM =
       messageLike.tool_calls || messageLike.kwargs?.tool_calls;
     if (toolCallsFromLLM && toolCallsFromLLM.length > 0) {
@@ -183,33 +184,114 @@ export function mapLangChainMessageToAGUI(message: BaseMessage): Message {
         },
       }));
     }
-  } else if (
+
+    return {
+      role: "assistant",
+      toolCalls,
+    };
+  }
+
+  if (
     message instanceof ToolMessage ||
     explicitRole === "tool" ||
     messageType === "tool"
   ) {
-    role = "tool";
     toolCallId = messageLike.tool_call_id || messageLike.kwargs?.tool_call_id;
-  } else if (
+    return {
+      role: "tool",
+      toolCallId,
+    };
+  }
+
+  if (
     message instanceof SystemMessage ||
     explicitRole === "system" ||
     messageType === "system"
   ) {
-    role = "system";
-  } else if (message instanceof ChatMessage) {
-    role = toRole(message.role) ?? "assistant";
-  } else if (explicitRole) {
-    role = explicitRole;
+    return { role: "system" };
   }
 
-  const content = mapContentForRole(role, messageLike.content);
+  if (message instanceof ChatMessage) {
+    role = toRole(message.role) ?? "assistant";
+    return { role };
+  }
 
-  return {
+  if (explicitRole) {
+    return { role: explicitRole };
+  }
+
+  return { role };
+}
+
+/**
+ * Maps a LangChain BaseMessage to an AG-UI Protocol Message.
+ *
+ * @param message - The LangChain message to map
+ * @returns An AG-UI Protocol compliant Message object
+ */
+export function mapLangChainMessageToAGUI(message: BaseMessage): Message {
+  const messageLike = message as MessageLike;
+  const id = messageLike.id || generateId();
+  const { role, toolCalls, toolCallId } = resolveRoleAndToolState(
+    message,
+    messageLike
+  );
+
+  if (role === "assistant") {
+    const assistantMessage: AssistantMessage = {
+      id,
+      role,
+      content: fallbackStringContent(messageLike.content),
+      toolCalls,
+      name: messageLike.name,
+    };
+    return assistantMessage;
+  }
+
+  if (role === "tool") {
+    const toolMessage: AGUIToolMessage = {
+      id,
+      role,
+      content: fallbackStringContent(messageLike.content),
+      toolCallId: toolCallId ?? generateId(),
+    };
+    return toolMessage;
+  }
+
+  if (role === "user") {
+    const userMessage: UserMessage = {
+      id,
+      role,
+      content: mapContentForRole(role, messageLike.content),
+      name: messageLike.name,
+    };
+    return userMessage;
+  }
+
+  if (role === "system") {
+    const systemMessage: AGUISystemMessage = {
+      id,
+      role,
+      content: fallbackStringContent(messageLike.content),
+      name: messageLike.name,
+    };
+    return systemMessage;
+  }
+
+  if (role === "developer") {
+    const developerMessage: DeveloperMessage = {
+      id,
+      role,
+      content: fallbackStringContent(messageLike.content),
+      name: messageLike.name,
+    };
+    return developerMessage;
+  }
+
+  const reasoningMessage: ReasoningMessage = {
     id,
     role,
-    content,
-    toolCalls,
-    toolCallId,
-    name: messageLike.name,
+    content: fallbackStringContent(messageLike.content),
   };
+  return reasoningMessage;
 }

--- a/packages/ag-ui-middleware-callbacks/src/utils/reasoning-blocks.ts
+++ b/packages/ag-ui-middleware-callbacks/src/utils/reasoning-blocks.ts
@@ -57,7 +57,7 @@ export function extractReasoningBlocks(message: BaseMessage): ReasoningBlock[] {
     return [];
   }
 
-  return contentBlocks.filter(isReasoningBlock);
+  return contentBlocks.filter(isReasoningBlock) as unknown as ReasoningBlock[];
 }
 
 /**

--- a/packages/ag-ui-middleware-callbacks/tests/unit/adapter/create-agui-adapter.test.ts
+++ b/packages/ag-ui-middleware-callbacks/tests/unit/adapter/create-agui-adapter.test.ts
@@ -252,6 +252,26 @@ describe("createAGUIAdapter", () => {
     expect(events).toHaveLength(0);
   });
 
+  test("rejects multiple consumers for the same adapter event stream", async () => {
+    const adapter = createAGUIAdapter({
+      agentFactory: ({ middleware }) =>
+        createAgent({
+          model: createTextModel(["Hello from adapter"]),
+          tools: [],
+          middleware: [middleware],
+        }),
+    });
+
+    const stream = await adapter.stream(createRunInput());
+
+    const firstPass = await collectEvents(stream);
+    await expect(collectEvents(stream)).rejects.toThrow(
+      "AGUI adapter event streams support a single consumer."
+    );
+
+    expect(firstPass.at(0)?.type).toBe("RUN_STARTED");
+  });
+
   test("matches backend canonical event types for equivalent runs", async () => {
     const config = {
       agentFactory: ({ middleware }: { middleware: any }) =>

--- a/packages/ag-ui-middleware-callbacks/tests/unit/adapter/create-agui-adapter.test.ts
+++ b/packages/ag-ui-middleware-callbacks/tests/unit/adapter/create-agui-adapter.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, test } from "bun:test";
+import type { BaseEvent, RunAgentInput } from "@ag-ui/core";
+import { BaseChatModel } from "@langchain/core/language_models/chat_models";
+import { AIMessage, AIMessageChunk } from "@langchain/core/messages";
+import { createAgent } from "langchain";
+import { createAGUIAdapter } from "../../../src/adapter";
+import { createAGUIBackend } from "../../../src/backend";
+import { createTextModel } from "../../helpers/test-utils";
+
+class FailingStreamingModel extends BaseChatModel {
+  constructor() {
+    super({
+      temperature: 0,
+      callbacks: undefined,
+      tags: undefined,
+      metadata: undefined,
+    });
+  }
+
+  protected _generate() {
+    return Promise.resolve({
+      generations: [
+        {
+          text: "unreachable",
+          message: new AIMessage({
+            content: "unreachable",
+          }),
+          generationInfo: {},
+        },
+      ],
+      llmOutput: {},
+    });
+  }
+
+  override async *_streamResponseChunks() {
+    await Promise.resolve();
+
+    yield {
+      message: new AIMessageChunk({
+        content: "x",
+      }),
+      generationInfo: {},
+    };
+
+    throw new Error("Model stream failed");
+  }
+
+  _llmType(): string {
+    return "failing_stream_model";
+  }
+
+  _call(): Promise<string> {
+    return Promise.reject(new Error("Model stream failed"));
+  }
+}
+
+function createRunInput(overrides: Partial<RunAgentInput> = {}): RunAgentInput {
+  return {
+    threadId: "thread-1",
+    runId: "run-1",
+    state: {},
+    messages: [
+      {
+        id: "msg-user-1",
+        role: "user",
+        content: "Hello",
+      },
+    ],
+    tools: [],
+    context: [],
+    forwardedProps: {},
+    ...overrides,
+  };
+}
+
+async function collectEvents(
+  stream: AsyncIterable<BaseEvent>
+): Promise<BaseEvent[]> {
+  const events: BaseEvent[] = [];
+
+  for await (const event of stream) {
+    events.push(event);
+  }
+
+  return events;
+}
+
+async function readSSEEvents(response: Response): Promise<BaseEvent[]> {
+  const body = response.body;
+  if (!body) {
+    return [];
+  }
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const events: BaseEvent[] = [];
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    buffer += decoder.decode(value, { stream: true });
+
+    let delimiterIndex = buffer.indexOf("\n\n");
+    while (delimiterIndex >= 0) {
+      const frame = buffer.slice(0, delimiterIndex);
+      buffer = buffer.slice(delimiterIndex + 2);
+
+      if (frame.startsWith("data: ")) {
+        events.push(JSON.parse(frame.slice(6)) as BaseEvent);
+      }
+
+      delimiterIndex = buffer.indexOf("\n\n");
+    }
+  }
+
+  return events;
+}
+
+describe("createAGUIAdapter", () => {
+  test("returns canonical lifecycle events without HTTP concerns", async () => {
+    const adapter = createAGUIAdapter({
+      agentFactory: ({ middleware }) =>
+        createAgent({
+          model: createTextModel(["Hello from adapter"]),
+          tools: [],
+          middleware: [middleware],
+        }),
+    });
+
+    const stream = await adapter.stream(createRunInput());
+    const events = await collectEvents(stream);
+    const types = events.map((event) => event.type);
+
+    expect(types).toContain("RUN_STARTED");
+    expect(types).toContain("RUN_FINISHED");
+    expect(types.at(0)).toBe("RUN_STARTED");
+    expect(types.at(-1)).toBe("RUN_FINISHED");
+  });
+
+  test("passes run state into the agent input", async () => {
+    let receivedInput: Record<string, unknown> | undefined;
+
+    const adapter = createAGUIAdapter({
+      agentFactory: () => ({
+        stream(input) {
+          receivedInput = input;
+
+          return Promise.resolve(
+            (async function* () {
+              await Promise.resolve();
+              yield {
+                ok: true,
+              };
+            })()
+          );
+        },
+      }),
+    });
+
+    const stream = await adapter.stream(
+      createRunInput({
+        state: {
+          sessionMode: "planner",
+          count: 3,
+        },
+      })
+    );
+
+    await collectEvents(stream);
+
+    expect(receivedInput).toEqual({
+      sessionMode: "planner",
+      count: 3,
+      messages: [
+        {
+          id: "msg-user-1",
+          role: "user",
+          content: "Hello",
+        },
+      ],
+    });
+  });
+
+  test("emits RUN_ERROR for post-start execution failures", async () => {
+    const adapter = createAGUIAdapter({
+      agentFactory: ({ middleware }) =>
+        createAgent({
+          model: new FailingStreamingModel(),
+          tools: [],
+          middleware: [middleware],
+        }),
+    });
+
+    const stream = await adapter.stream(createRunInput());
+    const events = await collectEvents(stream);
+    const types = events.map((event) => event.type);
+
+    expect(types).toContain("RUN_STARTED");
+    expect(types).toContain("RUN_ERROR");
+    expect(types.at(-1)).toBe("RUN_ERROR");
+  });
+
+  test("propagates aborts and closes without inventing RUN_ERROR", async () => {
+    let receivedSignal: AbortSignal | undefined;
+
+    const adapter = createAGUIAdapter({
+      agentFactory: () => ({
+        stream(_input, options) {
+          receivedSignal = options?.signal;
+
+          return Promise.resolve(
+            (async function* () {
+              await new Promise<void>((resolve, reject) => {
+                const signal = options?.signal;
+                if (!signal) {
+                  resolve();
+                  return;
+                }
+
+                if (signal.aborted) {
+                  reject(new DOMException("Aborted", "AbortError"));
+                  return;
+                }
+
+                const onAbort = () => {
+                  signal.removeEventListener("abort", onAbort);
+                  reject(new DOMException("Aborted", "AbortError"));
+                };
+
+                signal.addEventListener("abort", onAbort, { once: true });
+              });
+            })()
+          );
+        },
+      }),
+    });
+
+    const abortController = new AbortController();
+    const stream = await adapter.stream(createRunInput(), {
+      signal: abortController.signal,
+    });
+
+    abortController.abort();
+
+    const events = await collectEvents(stream);
+
+    expect(receivedSignal).toBe(abortController.signal);
+    expect(events).toHaveLength(0);
+  });
+
+  test("matches backend canonical event types for equivalent runs", async () => {
+    const config = {
+      agentFactory: ({ middleware }: { middleware: any }) =>
+        createAgent({
+          model: createTextModel(["Parity check"]),
+          tools: [],
+          middleware: [middleware],
+        }),
+    };
+
+    const adapter = createAGUIAdapter(config);
+    const backend = createAGUIBackend(config);
+    const input = createRunInput();
+
+    const adapterEvents = await collectEvents(await adapter.stream(input));
+    const backendEvents = await readSSEEvents(
+      await backend.handle(
+        new Request("https://example.test/agui", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(input),
+        })
+      )
+    );
+
+    expect(adapterEvents.map((event) => event.type)).toEqual(
+      backendEvents.map((event) => event.type)
+    );
+  });
+});

--- a/packages/ag-ui-middleware-callbacks/tests/unit/public-surface.test.ts
+++ b/packages/ag-ui-middleware-callbacks/tests/unit/public-surface.test.ts
@@ -10,7 +10,7 @@ import {
   AGUIMiddlewareOptionsSchema,
   createAGUIMiddleware as createMiddlewareFromSubpath,
 } from "../../src/middleware";
-import { createAGUIRunPublisher } from "../../src/publication";
+import { createAGUIRunPublisher, createSSEStream } from "../../src/publication";
 
 describe("public surface", () => {
   test("root export stays limited to low-level producers", async () => {
@@ -30,8 +30,9 @@ describe("public surface", () => {
     expect(AGUIMiddlewareOptionsSchema).toBeDefined();
   });
 
-  test("publication subpath exports run publisher API", () => {
+  test("publication subpath exports run publisher and SSE helpers", () => {
     expect(createAGUIRunPublisher).toBeDefined();
+    expect(createSSEStream).toBeDefined();
   });
 
   test("backend subpath exports backend factory API", () => {

--- a/packages/ag-ui-middleware-callbacks/tests/unit/public-surface.test.ts
+++ b/packages/ag-ui-middleware-callbacks/tests/unit/public-surface.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { createAGUIAdapter } from "../../src/adapter";
 import { createAGUIBackend } from "../../src/backend";
 import { AGUICallbackHandler as callbackHandlerFromSubpath } from "../../src/callbacks";
 import {
@@ -35,5 +36,9 @@ describe("public surface", () => {
 
   test("backend subpath exports backend factory API", () => {
     expect(createAGUIBackend).toBeDefined();
+  });
+
+  test("adapter subpath exports adapter factory API", () => {
+    expect(createAGUIAdapter).toBeDefined();
   });
 });

--- a/packages/ag-ui-middleware-callbacks/tests/unit/utils/message-mapper.test.ts
+++ b/packages/ag-ui-middleware-callbacks/tests/unit/utils/message-mapper.test.ts
@@ -54,6 +54,17 @@ describe("messageMapper", () => {
     expect(mapped.toolCallId).toBe("call_1");
   });
 
+  it("should reject ToolMessage values without a tool_call_id", () => {
+    const message = new ToolMessage({
+      content: '{"temp": 22}',
+      tool_call_id: "",
+    });
+
+    expect(() => mapLangChainMessageToAGUI(message)).toThrow(
+      "Cannot map a tool-role message without a toolCallId."
+    );
+  });
+
   it("should map SystemMessage to system role", () => {
     const message = new SystemMessage("System prompt");
     const mapped = mapLangChainMessageToAGUI(message);

--- a/packages/ag-ui-middleware-callbacks/tsconfig.json
+++ b/packages/ag-ui-middleware-callbacks/tsconfig.json
@@ -1,33 +1,34 @@
 {
-	"compilerOptions": {
-		// Environment setup & latest features
-		"lib": ["ESNext", "DOM"],
-		"target": "ESNext",
-		"module": "Preserve",
-		"moduleDetection": "force",
-		"jsx": "react-jsx",
-		"allowJs": true,
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext", "DOM"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
 
-		// Bundler mode
-		"moduleResolution": "bundler",
-		"baseUrl": ".",
-		"paths": {
-			"@/*": ["src/*"]
-		},
-		"allowImportingTsExtensions": true,
-		"verbatimModuleSyntax": true,
-		"noEmit": true,
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
 
-		// Best practices
-		"strict": true,
-		"skipLibCheck": true,
-		"noFallthroughCasesInSwitch": true,
-		"noUncheckedIndexedAccess": true,
-		"noImplicitOverride": true,
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
 
-		// Some stricter flags (disabled by default)
-		"noUnusedLocals": false,
-		"noUnusedParameters": false,
-		"noPropertyAccessFromIndexSignature": false
-	}
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  },
+  "include": ["src/**/*.ts"]
 }

--- a/packages/ag-ui-middleware-callbacks/tsup.config.ts
+++ b/packages/ag-ui-middleware-callbacks/tsup.config.ts
@@ -1,30 +1,31 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-	entry: {
-		backend: "src/backend.ts",
-		index: "src/index.ts",
-		callbacks: "src/callbacks.ts",
-		middleware: "src/middleware.ts",
-		publication: "src/publication.ts",
-	},
-	format: ["esm", "cjs"],
-	dts: true,
-	splitting: false,
-	sourcemap: true,
-	clean: true,
-	treeshake: true,
-	minify: true,
-	outExtension: ({ format }) => ({
-		js: format === "esm" ? ".js" : ".cjs",
-	}),
-	external: [
-		"langchain",
-		"@langchain/core",
-		"@langchain/langgraph",
-		"@ag-ui/core",
-		"@ag-ui/proto",
-		"zod",
-		"fast-json-patch",
-	],
+  entry: {
+    adapter: "src/adapter.ts",
+    backend: "src/backend.ts",
+    index: "src/index.ts",
+    callbacks: "src/callbacks.ts",
+    middleware: "src/middleware.ts",
+    publication: "src/publication.ts",
+  },
+  format: ["esm", "cjs"],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  minify: true,
+  outExtension: ({ format }) => ({
+    js: format === "esm" ? ".js" : ".cjs",
+  }),
+  external: [
+    "langchain",
+    "@langchain/core",
+    "@langchain/langgraph",
+    "@ag-ui/core",
+    "@ag-ui/proto",
+    "zod",
+    "fast-json-patch",
+  ],
 });


### PR DESCRIPTION
## Summary

This PR implements the first adapter-boundary epic for `@skroyc/ag-ui-middleware-callbacks`.

It adds a reusable `./adapter` public subpath, rebases the default backend on top of that shared adapter, and updates the advanced custom-host example to reuse the same orchestration semantics instead of rebuilding them locally.

## What Changed

- added `createAGUIAdapter()` as the shared non-HTTP orchestration surface
- published the additive `./adapter` export and build output
- refactored `createAGUIBackend()` into a thin HTTP plus SSE wrapper over the adapter
- updated the custom-host example to keep auth/routing local while delegating run orchestration to the shared adapter
- added adapter-level tests, backend/adapter parity coverage, and public-surface coverage for the new subpath
- updated package docs, example docs, and planning/audit docs to reflect the adapter-first code state
- cleaned up package/example formatting and typecheck paths so the package source and example workspace both typecheck cleanly
- tightened message and reasoning typing to lean on `@ag-ui/core` types instead of maintaining extra local AG-UI-like shapes

## Why

The package had already grown beyond a producer-only shape, but the reusable adapter boundary was still implicit. That left the backend and custom-host path duplicating the same orchestration concerns and made the public contract harder to reason about.

This change makes the adapter explicit, keeps HTTP concerns in the backend layer, and gives custom hosts a trustworthy programmatic seam that emits canonical AG-UI events without transport-specific behavior.

## Impact

- builders can now import `@skroyc/ag-ui-middleware-callbacks/adapter` directly for host-owned auth/routing/transport scenarios
- the backend path preserves its public behavior while reusing the same underlying semantics as custom hosts
- docs and examples now describe the current package behavior instead of the pre-extraction target state

## Validation

- `bunx --bun @biomejs/biome check` on the touched package/example/docs files
- `bunx tsc --noEmit -p packages/ag-ui-middleware-callbacks/tsconfig.json`
- `bunx tsc --noEmit -p packages/ag-ui-middleware-callbacks/example/tsconfig.json`
- `bun test packages/ag-ui-middleware-callbacks`
- `bun run --filter @skroyc/ag-ui-middleware-callbacks build`
- `EXAMPLE_PROVIDER=mock bun run verify.ts default "Calculate 2 + 2"`
- `EXAMPLE_PROVIDER=mock bun run verify.ts custom-host "Calculate 2 + 2"`

## Notes

The example verifier will fail with a live-provider `RUN_ERROR` if the shell auto-loads a missing external model from `.env`; the mock-provider checks above were used to verify the adapter refactor itself deterministically.
